### PR TITLE
[fix] prevent trying to require system junk files (.DS_Store, etc..)

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const fs = require("fs");
 const path = require("path");
 const clear = require("clear");
 const chalk = require("chalk");
-
+const junk = require("junk");
 const utils = require(path.join(__dirname, "lib", "utils", "utils"));
 
 // process command line arguments
@@ -12,7 +12,7 @@ let args = require("minimist")(process.argv.slice(2));
 // console.log(args);
 
 //// Load the command list:
-var listFiles = fs.readdirSync(path.join(__dirname, "lib"));
+var listFiles = fs.readdirSync(path.join(__dirname, "lib")).filter(junk.not);
 var commandHash = {};
 listFiles.forEach(file => {
   var stat = fs.statSync(path.join(__dirname, "lib", file));

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "cross-spawn": "^6.0.5",
     "ejs": "^2.6.1",
     "inquirer": "^6.2.1",
+    "junk": "^2.1.0",
     "minimist": "^1.2.0",
     "nanoid": "^2.0.1",
     "shelljs": "^0.8.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -499,6 +499,11 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
+junk@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/junk/-/junk-2.1.0.tgz#f431b4b7f072dc500a5f10ce7f4ec71930e70134"
+  integrity sha1-9DG0t/By3FAKXxDOf07HGTDnATQ=
+
 levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"


### PR DESCRIPTION
I'm trying to prevent errors when there are special system files in our /lib directory.