### PR TITLE
Allow nginx and SSL options to be passed via command line

### DIFF
--- a/lib/installV1.js
+++ b/lib/installV1.js
@@ -158,22 +158,6 @@ function checkDependencies(done) {
 }
 
 /**
- * @function unstringifyBools
- * convert boolean inputs from strings into actual bools within a flat array
- */
-function unstringifyBools(inputArray) {
-   for (var i in inputArray) {
-      if (inputArray[i] == "false") {
-         inputArray[i] = false;
-      }
-      if (inputArray[i] == "true") {
-         inputArray[i] = true;
-      }
-   }
-   return inputArray;
-}
-
-/**
  * @function setupDB
  * run the configDB setup command.
  * @param {cb(err)} done
@@ -201,7 +185,7 @@ function setupDB(done) {
       }
    }
 
-   dbOptions = unstringifyBools(dbOptions);
+   dbOptions = utils.unstringifyBools(dbOptions);
    configDBCommand
       .run(dbOptions)
       .then(done)
@@ -215,7 +199,7 @@ function configureNGINX(done) {
    for (var i in Options.nginx) {
       nOptions[i] = Options.nginx[i];
    }
-   nOptions = unstringifyBools(nOptions);
+   nOptions = utils.unstringifyBools(nOptions);
    nOptions.port = Options.port;
 
    var config = require(path.join(__dirname, "tasks", "configNginx.js"));

--- a/lib/installV1.js
+++ b/lib/installV1.js
@@ -158,6 +158,23 @@ function checkDependencies(done) {
 }
 
 /**
+ * @function unstringifyBools
+ * convert boolean inputs from strings into actual bools within a flat array
+ */
+function unstringifyBools(inputArray) {
+
+   for (var i in inputArray) {
+      if (inputArray[i] == "false") {
+         inputArray[i] = false;
+      }
+      if (inputArray[i] == "true") {
+         inputArray[i] = true;
+      }
+   }
+   return inputArray;
+}
+
+/**
  * @function setupDB
  * run the configDB setup command.
  * @param {cb(err)} done
@@ -185,15 +202,7 @@ function setupDB(done) {
       }
    }
 
-   for (var oo in dbOptions) {
-      if (dbOptions[oo] == "false") {
-         dbOptions[oo] = false;
-      }
-      if (dbOptions[oo] == "true") {
-         dbOptions[oo] = true;
-      }
-   }
-   // console.log(JSON.stringify(dbOptions, null, 4));
+   dbOptions = unstringifyBools(dbOptions);
    configDBCommand
       .run(dbOptions)
       .then(done)
@@ -201,7 +210,14 @@ function setupDB(done) {
 }
 
 function configureNGINX(done) {
+
    var nOptions = {};
+
+   // filter on arguments passed in in the form of "--nginx.arg"
+   for (var i in Options.nginx) {
+      nOptions[i] = Options.nginx[i];
+   }
+   // filter on arguments passed in in the form of "--nginxArg"
    for (var o in Options) {
       if (o.indexOf("nginx") == 0 && o.length > 5) {
          var o2 = o.replace("db", "");
@@ -209,14 +225,8 @@ function configureNGINX(done) {
          nOptions[key] = Options[o];
       }
    }
-   for (var oo in nOptions) {
-      if (nOptions[oo] == "false") {
-         nOptions[oo] = false;
-      }
-      if (nOptions[oo] == "true") {
-         nOptions[oo] = true;
-      }
-   }
+
+   nOptions = unstringifyBools(nOptions);
    nOptions.port = Options.port;
 
    var config = require(path.join(__dirname, "tasks", "configNginx.js"));
@@ -541,7 +551,7 @@ function questions(done) {
             default: false,
             when: (values) => {
                return (
-                  !values.dbExpose && typeof Options.dbExpose == "undefined"
+                  !values.dbExpose && typeof(Options.dbExpose) == "undefined"
                );
             }
          },
@@ -582,7 +592,7 @@ function questions(done) {
             message: "Do you want to expose Arango DB:",
             default: false,
             when: (values) => {
-               return !values.arangoExpose && !Options.arangoExpose;
+               return !values.arangoExpose && typeof(Options.arangoExpose) == "undefined"
             }
          },
          {

--- a/lib/installV1.js
+++ b/lib/installV1.js
@@ -162,7 +162,6 @@ function checkDependencies(done) {
  * convert boolean inputs from strings into actual bools within a flat array
  */
 function unstringifyBools(inputArray) {
-
    for (var i in inputArray) {
       if (inputArray[i] == "false") {
          inputArray[i] = false;
@@ -210,22 +209,12 @@ function setupDB(done) {
 }
 
 function configureNGINX(done) {
-
    var nOptions = {};
 
-   // filter on arguments passed in in the form of "--nginx.arg"
+   // filter on arguments passed in in the form of "--nginx.arg", remove the prefix and pass the remaining args on
    for (var i in Options.nginx) {
       nOptions[i] = Options.nginx[i];
    }
-   // filter on arguments passed in in the form of "--nginxArg"
-   for (var o in Options) {
-      if (o.indexOf("nginx") == 0 && o.length > 5) {
-         var o2 = o.replace("db", "");
-         var key = `${o2.charAt(0).toLowerCase() + o2.slice(1)}`;
-         nOptions[key] = Options[o];
-      }
-   }
-
    nOptions = unstringifyBools(nOptions);
    nOptions.port = Options.port;
 
@@ -551,7 +540,8 @@ function questions(done) {
             default: false,
             when: (values) => {
                return (
-                  !values.dbExpose && typeof(Options.dbExpose) == "undefined"
+                  typeof values.dbExpose == "undefined" &&
+                  typeof Options.dbExpose == "undefined"
                );
             }
          },
@@ -592,7 +582,10 @@ function questions(done) {
             message: "Do you want to expose Arango DB:",
             default: false,
             when: (values) => {
-               return !values.arangoExpose && typeof(Options.arangoExpose) == "undefined"
+               return (
+                  typeof values.arangoExpose == "undefined" &&
+                  typeof Options.arangoExpose == "undefined"
+               );
             }
          },
          {

--- a/lib/ssl.js
+++ b/lib/ssl.js
@@ -67,6 +67,7 @@ Command.help = function() {
 `);
 };
 
+
 /**
  * @function run
  * perform the action for this command.
@@ -74,6 +75,7 @@ Command.help = function() {
  *        provided parameters for this command
  */
 Command.run = function(options) {
+
    return new Promise((resolve, reject) => {
       // doProcess: {array} of async fns to be processed for our command.
       var doProcess = [];
@@ -109,6 +111,15 @@ Command.run = function(options) {
          }
       });
 
+      function sslType(values, options) {
+	var sslType = undefined;  
+        if ( values.process ) sslType = values.process;
+	else if ( options.self )  sslType = "self";
+	else if ( options.none )  sslType = "none";
+	else if ( options.exist ) sslType = "exist";
+	return sslType;
+      }
+
       inquirer
          .prompt([
             {
@@ -133,12 +144,7 @@ Command.run = function(options) {
                   }
                ],
                when: (values) => {
-                  return (
-                     !values.process &&
-                     !options.self &&
-                     !options.none &&
-                     !options.exist
-                  );
+                  return ( sslType(values, options) == undefined );
                }
             },
             {
@@ -147,7 +153,7 @@ Command.run = function(options) {
                message: "Country Name (2 letter code):",
                when: (values) => {
                   // only display this question if we answered 'self' to 1st prompt
-                  return values.process == "self" && !options.sslCountryName;
+                  return sslType(values, options) == "self" && !options.sslCountryName;
                }
             },
             {
@@ -156,7 +162,7 @@ Command.run = function(options) {
                message: "State or Province Name (full name):",
                when: (values) => {
                   // only display this question if we answered 'self' to 1st prompt
-                  return values.process == "self" && !options.sslProvinceName;
+                  return sslType(values, options) == "self" && !options.sslProvinceName;
                }
             },
             {
@@ -165,7 +171,7 @@ Command.run = function(options) {
                message: "Locality Name (name of city):",
                when: (values) => {
                   // only display this question if we answered 'self' to 1st prompt
-                  return values.process == "self" && !options.sslLocalityName;
+                  return sslType(values, options) == "self" && !options.sslLocalityName;
                }
             },
             {
@@ -175,7 +181,7 @@ Command.run = function(options) {
                when: (values) => {
                   // only display this question if we answered 'self' to 1st prompt
                   return (
-                     values.process == "self" && !options.sslOrganizationName
+                     sslType(values, options) == "self" && !options.sslOrganizationName
                   );
                }
             },
@@ -185,7 +191,7 @@ Command.run = function(options) {
                message: "Organizational Unit Name (name of section):",
                when: (values) => {
                   // only display this question if we answered 'self' to 1st prompt
-                  return values.process == "self" && !options.sslUnitName;
+                  return sslType(values, options) == "self" && !options.sslUnitName;
                }
             },
             {
@@ -194,7 +200,7 @@ Command.run = function(options) {
                message: "Common Name (host name):",
                when: (values) => {
                   // only display this question if we answered 'self' to 1st prompt
-                  return values.process == "self" && !options.sslCommonName;
+                  return sslType(values, options) == "self" && !options.sslCommonName;
                }
             },
             {
@@ -203,7 +209,7 @@ Command.run = function(options) {
                message: "Email Address:",
                when: (values) => {
                   // only display this question if we answered 'self' to 1st prompt
-                  return values.process == "self" && !options.sslEmailAddress;
+                  return sslType(values, options) == "self" && !options.sslEmailAddress;
                }
             },
             {
@@ -212,7 +218,7 @@ Command.run = function(options) {
                message: "A challenge password:",
                when: (values) => {
                   // only display this question if we answered 'self' to 1st prompt
-                  return values.process == "self" && !options.sslChallengePW;
+                  return sslType(values, options) == "self" && !options.sslChallengePW;
                },
                validate: (value) => {
                   return value.length >= 4
@@ -228,7 +234,7 @@ Command.run = function(options) {
                when: (values) => {
                   // only display this question if we answered 'exist' to 1st prompt
                   return (
-                     values.process == "exist" &&
+                     sslType(values, options) == "exist" &&
                      (!options.pathKey ||
                         !fs.statSync(options.pathKey).isFile())
                   );
@@ -244,7 +250,7 @@ Command.run = function(options) {
                when: (values) => {
                   // only display this question if we answered 'exist' to 1st prompt
                   return (
-                     values.process == "exist" &&
+                     sslType(values, options) == "exist" &&
                      (!options.pathCert ||
                         !fs.statSync(options.pathCert).isFile())
                   );
@@ -252,16 +258,16 @@ Command.run = function(options) {
             }
          ])
          .then((answers) => {
-            // console.log("options", options);
-            // console.log("answers:", answers);
+            //console.log("options", options);
+            //console.log("answers:", answers);
             for (var o in options) {
                Options[o] = options[o];
             }
             for (var a in answers) {
                Options[a] = answers[a];
             }
-            // console.log("Options:", Options);
-            switch (answers.process) {
+            //console.log("Options:", Options);
+            switch (sslType(answers, options)) {
                case "self":
                   doProcess.push(processSelfSignedCert);
                   break;

--- a/lib/ssl.js
+++ b/lib/ssl.js
@@ -67,7 +67,6 @@ Command.help = function() {
 `);
 };
 
-
 /**
  * @function run
  * perform the action for this command.
@@ -75,7 +74,6 @@ Command.help = function() {
  *        provided parameters for this command
  */
 Command.run = function(options) {
-
    return new Promise((resolve, reject) => {
       // doProcess: {array} of async fns to be processed for our command.
       var doProcess = [];
@@ -112,12 +110,12 @@ Command.run = function(options) {
       });
 
       function sslType(values, options) {
-	var sslType = undefined;  
-        if ( values.process ) sslType = values.process;
-	else if ( options.self )  sslType = "self";
-	else if ( options.none )  sslType = "none";
-	else if ( options.exist ) sslType = "exist";
-	return sslType;
+         var sslType = undefined;
+         if (values.process) sslType = values.process;
+         else if (options.self) sslType = "self";
+         else if (options.none) sslType = "none";
+         else if (options.exist) sslType = "exist";
+         return sslType;
       }
 
       inquirer
@@ -144,7 +142,7 @@ Command.run = function(options) {
                   }
                ],
                when: (values) => {
-                  return ( sslType(values, options) == undefined );
+                  return sslType(values, options) == undefined;
                }
             },
             {
@@ -153,7 +151,10 @@ Command.run = function(options) {
                message: "Country Name (2 letter code):",
                when: (values) => {
                   // only display this question if we answered 'self' to 1st prompt
-                  return sslType(values, options) == "self" && !options.sslCountryName;
+                  return (
+                     sslType(values, options) == "self" &&
+                     !options.sslCountryName
+                  );
                }
             },
             {
@@ -162,7 +163,10 @@ Command.run = function(options) {
                message: "State or Province Name (full name):",
                when: (values) => {
                   // only display this question if we answered 'self' to 1st prompt
-                  return sslType(values, options) == "self" && !options.sslProvinceName;
+                  return (
+                     sslType(values, options) == "self" &&
+                     !options.sslProvinceName
+                  );
                }
             },
             {
@@ -171,7 +175,10 @@ Command.run = function(options) {
                message: "Locality Name (name of city):",
                when: (values) => {
                   // only display this question if we answered 'self' to 1st prompt
-                  return sslType(values, options) == "self" && !options.sslLocalityName;
+                  return (
+                     sslType(values, options) == "self" &&
+                     !options.sslLocalityName
+                  );
                }
             },
             {
@@ -181,7 +188,8 @@ Command.run = function(options) {
                when: (values) => {
                   // only display this question if we answered 'self' to 1st prompt
                   return (
-                     sslType(values, options) == "self" && !options.sslOrganizationName
+                     sslType(values, options) == "self" &&
+                     !options.sslOrganizationName
                   );
                }
             },
@@ -191,7 +199,9 @@ Command.run = function(options) {
                message: "Organizational Unit Name (name of section):",
                when: (values) => {
                   // only display this question if we answered 'self' to 1st prompt
-                  return sslType(values, options) == "self" && !options.sslUnitName;
+                  return (
+                     sslType(values, options) == "self" && !options.sslUnitName
+                  );
                }
             },
             {
@@ -200,7 +210,10 @@ Command.run = function(options) {
                message: "Common Name (host name):",
                when: (values) => {
                   // only display this question if we answered 'self' to 1st prompt
-                  return sslType(values, options) == "self" && !options.sslCommonName;
+                  return (
+                     sslType(values, options) == "self" &&
+                     !options.sslCommonName
+                  );
                }
             },
             {
@@ -209,7 +222,10 @@ Command.run = function(options) {
                message: "Email Address:",
                when: (values) => {
                   // only display this question if we answered 'self' to 1st prompt
-                  return sslType(values, options) == "self" && !options.sslEmailAddress;
+                  return (
+                     sslType(values, options) == "self" &&
+                     !options.sslEmailAddress
+                  );
                }
             },
             {
@@ -218,7 +234,10 @@ Command.run = function(options) {
                message: "A challenge password:",
                when: (values) => {
                   // only display this question if we answered 'self' to 1st prompt
-                  return sslType(values, options) == "self" && !options.sslChallengePW;
+                  return (
+                     sslType(values, options) == "self" &&
+                     !options.sslChallengePW
+                  );
                },
                validate: (value) => {
                   return value.length >= 4

--- a/lib/tasks/configNginx.js
+++ b/lib/tasks/configNginx.js
@@ -34,7 +34,6 @@ Command.help = function() {
 };
 
 Command.run = function(options) {
-
    return new Promise((resolve, reject) => {
       async.series(
          [
@@ -74,12 +73,15 @@ function questions(done) {
    inquirer
       .prompt([
          {
-            name: "nginxEnable",
+            name: "enable",
             type: "confirm",
             message: "Use nginx as a proxy server?",
             default: true,
             when: (values) => {
-               return !values.nginxEnable && typeof(Options.nginxEnable) == "undefined"
+               return (
+                  typeof values.enable == "undefined" &&
+                  typeof Options.enable == "undefined"
+               );
             }
          }
       ])
@@ -99,7 +101,8 @@ function questions(done) {
  * @param {cb(err)} done
  */
 function insertDockerConfig(done) {
-   if (!Options.nginxEnable) {
+   if (!Options.enable) {
+      console.log("nginx: not using nginx as a proxy server");
       done();
       return;
    }
@@ -147,25 +150,25 @@ function setupSSL(done) {
    // "ssl.none"
    var sslOptions = Options.ssl || {};
 
-   /// handle any arguments that are in the form of "--ssl.arg"
+   // handle any arguments that are in the form of "--ssl.arg"
    for (var o in Options) {
       var parts = o.split(".");
       if (parts[0] == "ssl") {
          sslOptions[parts[1]] = Options[o];
       }
    }
-   /// handle any arguments that are in the form of "[nginx.]sslArg"
+   // handle arguments in the form of "[--nginx.]sslArg"
+   // but the prefix prior to the dot have already been filtered and removed.
    for (var i in Options) {
       if (i == "sslType") {
-	var sslType = Options[i];
-        sslOptions[sslType] = true;
-        sslOptions["process"] = sslType;
-      }
-      else if ( i.indexOf("ssl") == 0 && i.length > 3 ) {
-        sslOptions[i] = Options[i];
+         var sslType = Options[i];
+         sslOptions[sslType] = true;
+         sslOptions["process"] = sslType;
+      } else if (i.indexOf("ssl") == 0 && i.length > 3) {
+         sslOptions[i] = Options[i];
       }
    }
-   
+
    sslCommand
       .run(sslOptions)
       .then(done)

--- a/lib/tasks/configNginx.js
+++ b/lib/tasks/configNginx.js
@@ -34,6 +34,7 @@ Command.help = function() {
 };
 
 Command.run = function(options) {
+
    return new Promise((resolve, reject) => {
       async.series(
          [
@@ -78,7 +79,7 @@ function questions(done) {
             message: "Use nginx as a proxy server?",
             default: true,
             when: (values) => {
-               return !values.nginxEnable && !Options.nginxEnable;
+               return !values.nginxEnable && typeof(Options.nginxEnable) == "undefined"
             }
          }
       ])
@@ -145,13 +146,26 @@ function setupSSL(done) {
    // "ssl.pathKey ssl.pathCert"
    // "ssl.none"
    var sslOptions = Options.ssl || {};
+
+   /// handle any arguments that are in the form of "--ssl.arg"
    for (var o in Options) {
       var parts = o.split(".");
       if (parts[0] == "ssl") {
          sslOptions[parts[1]] = Options[o];
       }
    }
-
+   /// handle any arguments that are in the form of "[nginx.]sslArg"
+   for (var i in Options) {
+      if (i == "sslType") {
+	var sslType = Options[i];
+        sslOptions[sslType] = true;
+        sslOptions["process"] = sslType;
+      }
+      else if ( i.indexOf("ssl") == 0 && i.length > 3 ) {
+        sslOptions[i] = Options[i];
+      }
+   }
+   
    sslCommand
       .run(sslOptions)
       .then(done)

--- a/lib/utils/unstringifyBools.js
+++ b/lib/utils/unstringifyBools.js
@@ -1,19 +1,19 @@
 //
 // unstringifyBools
-// changes "true" and "false" strings into actual boolean values throughout an array
+// changes "true" and "false" strings into actual boolean values throughout an object
 //
 
 /**
  * unstringifyBools
- * convert boolean inputs from strings into actual bools within a flat array
- * @param {array} inputArray  the array to process
+ * convert booleans from strings into actual bools within an object
+ * @param {array} input  the object to process
  * @return {array}
  */
 
-module.exports = function unstringifyBools(inputArray) {
-   for (var i in inputArray) {
-      if (inputArray[i] == "false") inputArray[i] = false;
-      if (inputArray[i] == "true") inputArray[i] = true;
+module.exports = function unstringifyBools(input) {
+   for (var i in input) {
+      if (input[i] == "false") input[i] = false;
+      if (input[i] == "true") input[i] = true;
    }
-   return inputArray;
+   return input;
 };

--- a/lib/utils/unstringifyBools.js
+++ b/lib/utils/unstringifyBools.js
@@ -1,0 +1,19 @@
+//
+// unstringifyBools
+// changes "true" and "false" strings into actual boolean values throughout an array
+//
+
+/**
+ * unstringifyBools
+ * convert boolean inputs from strings into actual bools within a flat array
+ * @param {array} inputArray  the array to process
+ * @return {array}
+ */
+
+module.exports = function unstringifyBools(inputArray) {
+   for (var i in inputArray) {
+      if (inputArray[i] == "false") inputArray[i] = false;
+      if (inputArray[i] == "true") inputArray[i] = true;
+   }
+   return inputArray;
+};

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -27,6 +27,7 @@ var Resource = require(path.join(__dirname, "resource"));
 var stringPad = require(path.join(__dirname, "stringPad"));
 var stringRender = require(path.join(__dirname, "stringRender"));
 var stringReplaceAll = require(path.join(__dirname, "stringReplaceAll"));
+var unstringifyBools = require(path.join(__dirname, "unstringifyBools"));
 
 module.exports = {
    checkDependencies,
@@ -49,5 +50,6 @@ module.exports = {
    Resource,
    stringPad,
    stringRender,
-   stringReplaceAll
+   stringReplaceAll,
+   unstringifyBools
 };


### PR DESCRIPTION
The following set of commands now work with no user interaction
```
appbuilder install $WORKING_DIR \
        --V1 \
        --develop \
        --port=6500 \
        --db.port=6501 \
        --db.password=r00t \
        --db.expose=true \
        --db.encryption=false \
        --arango.port=6502 \
        --arango.password=r00t \
        --arango.expose=false \
        --nginxEnable=false \
        --nginx.sslType=none 
```