### PR TITLE
[add] install option to use a branch/commit of ab_runtime

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -59,6 +59,7 @@ jobs:
           working-directory: ./ab-test
           config: responseTimeout=60000
           project: ./test/e2e
+          install: false
 
       - name: Take Down Test Stack
         run: node ../index.js test down ab
@@ -77,6 +78,7 @@ jobs:
           wait-on: "http://localhost:80"
           wait-on-timeout: 300
           env: stack=ab
+          install: false
 
       - name: Take Down Main Stack
         run: ./Down.sh

--- a/lib/install.js
+++ b/lib/install.js
@@ -215,6 +215,12 @@ function cloneRepo(done) {
    );
 
    shell.pushd("-q", Options.name);
+
+   // Allow installing using a branch or commit in ab_runtime --runtime [branch/commit]
+   if (Options.runtime) {
+      shell.exec(`git checkout ${Options.runtime}`);
+   }
+
    done();
 }
 


### PR DESCRIPTION
This is mainly so that we can run our e2e tests on changes to `ab_runtime`