### PR TITLE
[add] enabled custom_reports

### DIFF
--- a/templates/setup/config/local.js
+++ b/templates/setup/config/local.js
@@ -76,6 +76,15 @@ module.exports = {
    /* end bot_manager */
 
    /**
+    * custom_reports
+    * service for managing our multi-tenant aware AB requests
+    */
+   custom_reports: {
+      enable: true,
+   },
+   /* end custom_reports */
+
+   /**
     * definition_manager
     * service for managing our multi-tenant aware AB requests
     */


### PR DESCRIPTION
WARNING: This will enable the service on all installs

This is probably not the correct solution, should tests be able to edit how the config file is setup?