### PR TITLE
Run db migrations after initializing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,8 @@ lib-cov
 node_modules/
 
 leftOffHere.txt
+
+# Install Test Directories
 ab-test/
+ti-*/
+test-*/

--- a/lib/install.js
+++ b/lib/install.js
@@ -111,6 +111,7 @@ Command.run = function (options) {
             configTenantAdmin,
             initializeConfig,
             initializeDB,
+            runDbMigrations,
          ],
          (err) => {
             // now make sure we have popd() all remaining directories
@@ -439,12 +440,25 @@ function initializeConfig(done) {
 function initializeDB(done) {
    console.log();
    console.log("initialize the DB tables");
+   const options = { ...Options };
+   // Keep this stack running for DB migrations
+   options.keepRunning = true;
    utils
-      .dbInit(Options, "dbinit-compose.yml")
+      .dbInit(options, "dbinit-compose.yml")
       .then(() => {
          done();
       })
       .catch(done);
    // shell.exec(path.join(process.cwd(), "DBInit.js"));
    // done();
+}
+
+/**
+ * run our db migrations from migration manager
+ */
+function runDbMigrations(done) {
+   console.log();
+   console.log("run db migration scripts");
+   utils.runDbMigrations(Options);
+   return done();
 }

--- a/lib/tasks/testSetup.js
+++ b/lib/tasks/testSetup.js
@@ -65,6 +65,7 @@ Command.run = function (options) {
 
             generateTestConfigs,
             createMissingVolume,
+            runDbMigrations,
             removeSetupStack,
             waitClosed,
          ],
@@ -184,6 +185,15 @@ function waitClosed(done) {
    } else {
       done();
    }
+}
+
+/**
+ * run our db migrations from migration manager
+ */
+function runDbMigrations(done) {
+   console.log("Run db migration scripts");
+   utils.runDbMigrations(Options);
+   return done();
 }
 
 /**

--- a/lib/utils/runDbMigrations.js
+++ b/lib/utils/runDbMigrations.js
@@ -1,0 +1,26 @@
+//
+// runDbMigrations
+// run the db migrations (using ab migration manager)
+//
+//
+const shelljs = require("shelljs");
+const path = require("path");
+/**
+ * run the db migrations (using ab migration manager).
+ * Note: expects the options.stack to be running with db conatiner.
+ * @param {object} options
+ */
+module.exports = function ({ stack, keepRunning /*, tag */ }) {
+   const tag = "master"; // only have the master tag built currently
+   const network = `${stack}_default`;
+   const pathConfig = path.join(process.cwd(), "/config/local.js");
+
+   shelljs.exec(
+      `docker run -v ${pathConfig}:/app/config/local.js --network=${network} digiserve/ab-migration-manager:${tag} node app.js`
+   );
+
+   if (!keepRunning) {
+      console.log("... shutting down");
+      shelljs.exec(`docker stack rm ${stack}`, { silent: true });
+   }
+};

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -32,6 +32,7 @@ var httpPost = require(path.join(__dirname, "httpPost"));
 var optionsPull = require(path.join(__dirname, "optionsPull"));
 var portInUse = require(path.join(__dirname, "portInUse"));
 var Resource = require(path.join(__dirname, "resource"));
+const runDbMigrations = require(path.join(__dirname, "runDbMigrations"));
 var stringPad = require(path.join(__dirname, "stringPad"));
 var stringRender = require(path.join(__dirname, "stringRender"));
 var stringReplaceAll = require(path.join(__dirname, "stringReplaceAll"));
@@ -63,6 +64,7 @@ module.exports = {
    optionsPull,
    portInUse,
    Resource,
+   runDbMigrations,
    stringPad,
    stringRender,
    stringReplaceAll,


### PR DESCRIPTION
From discussion here: https://github.com/digi-serve/ab_runtime/pull/50#issuecomment-1386000889
`03-site_tables.sql` will not be kept up to date, so we need to run migrations from [ab_migration_manager](https://github.com/digi-serve/ab_migration_manager) on new installs.