### PR TITLE
Convert our platform into a more AWS friendly format

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,7 @@ module.exports = {
    env: {
       node: true,
       browser: true,
-      es6: true,
+      es2020: true,
    },
 
    parserOptions: {

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -47,7 +47,7 @@ jobs:
         run: docker swarm init --advertise-addr 127.0.0.1
 
       - name: Install AppBuilder
-        run: npm run ci:dev-install
+        run: npm run ci:dev-install -- --runtime=${{ github.head_ref }}
 
       # Give some time for the stack to come down fully
       - run: sleep 15

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -47,7 +47,7 @@ jobs:
         run: docker swarm init --advertise-addr 127.0.0.1
 
       - name: Install AppBuilder
-        run: npm run ci:dev-install -- --runtime=${{ github.head_ref }}
+        run: node index.js install ab-test --stack=ab-test --develop --port=80 --tag=develop --dbExpose=true --dbPort=8888 --dbPassword=root --authType=login --relayEnabled=false --siteURL=http://localhost:80 --tenant.username=admin --tenant.password=admin --tenant.email=admin@email.com --tenant.url=http://localhost:80 -- --runtime=${{ github.head_ref }}
 
       # Give some time for the stack to come down fully
       - run: sleep 15

--- a/lib/install.js
+++ b/lib/install.js
@@ -117,6 +117,7 @@ Command.run = function (options) {
             // devInstallServices,
             // devInstallPlugins,
             compileUI,
+            downStack,
          ],
          (err) => {
             // now make sure we have popd() all remaining directories
@@ -300,8 +301,9 @@ function installDeveloperFiles(done) {
    }
 
    console.log("Installing Developer Files");
+   // TODO:  return to :develop
    shell.exec(
-      `docker run -v ${process.cwd()}:/app/dest digiserve/ab-code-developer:master`,
+      `docker run -v ${process.cwd()}:/app/dest digiserve/ab-code-developer:awsready`,
       { silent: true }
    );
 
@@ -531,4 +533,14 @@ function runDbMigrations(done) {
    };
    utils.runDbMigrations(params);
    return done();
+}
+
+/**
+ * @function downStack()
+ * bring the stack back down to finish out our install
+ */
+function downStack(done) {
+   console.log("Bringing down the Stack");
+   shell.exec(`docker stack rm ${Options.stack}`, { silent: true });
+   done();
 }

--- a/lib/install.js
+++ b/lib/install.js
@@ -6,7 +6,7 @@
 //  --developer   :  setup the environment for a developer
 //
 var async = require("async");
-// var fs = require("fs");
+var fs = require("fs");
 var path = require("path");
 var shell = require("shelljs");
 var utils = require(path.join(__dirname, "utils", "utils"));
@@ -60,6 +60,9 @@ Command.help = function () {
     --tenant.email    [string] : the default tenant admin email
     --tenant.url      [string] : the default tenant admin url
 
+    --runtime [branch] : allow checking out another branch of our ab_runtime
+
+
   examples:
 
     $ appbuilder install ABv2
@@ -105,13 +108,15 @@ Command.run = function (options) {
             cloneRepo,
             installDependencies,
             runSetup,
-            devInstallServices,
-            devInstallPlugins,
-            compileUI,
-            configTenantAdmin,
-            initializeConfig,
+            copyDBInit,
             initializeDB,
             runDbMigrations,
+            removeTempDBInitFiles,
+            configTenantAdmin,
+            installDeveloperFiles,
+            // devInstallServices,
+            // devInstallPlugins,
+            compileUI,
          ],
          (err) => {
             // now make sure we have popd() all remaining directories
@@ -258,75 +263,127 @@ function runSetup(done) {
 }
 
 /**
- * @function devInstallServices
- * install all of our development services.
+ * @function copyDBInit
+ * copy over the dbinit-compose.yml file
+ * This is just temporary for the initial install step.
  * @param {cb(err)} done
  */
-function devInstallServices(done) {
+function copyDBInit(done) {
+   const pathTemplate = path.join(
+      utils.fileTemplatePath(),
+      "_dbinit-compose.yml"
+   );
+   const contents = utils.fileRender(pathTemplate, Options);
+   fs.writeFileSync("dbinit-compose.yml", contents);
+   done();
+}
+
+/**
+ * @function removeTempDBInitFiles
+ * remove any of the temp files left from DB Init
+ * @param {cb(err)} done
+ */
+function removeTempDBInitFiles(done) {
+   shell.rm("dbinit-compose.yml", "delme.yml");
+   done();
+}
+
+/**
+ * @function installDeveloperFiles
+ * perform the developer/ setup
+ * @param {cb(err)} done
+ */
+function installDeveloperFiles(done) {
    if (!Options.develop) {
       done();
       return;
    }
-   // always install the UI platform:
-   var services = ["ab_platform_web"];
 
-   async.series(
-      [
-         (next) => {
-            utils.gitScanDevYML((err, list) => {
-               if (err) {
-                  done(err);
-                  return;
-               }
-               services = services.concat(list);
-               next();
-            });
-         },
-         (next) => {
-            // now install the repos:
-            utils.gitInstallServices(
-               services,
-               { silent: Options.travisCI },
-               next
-            );
-         },
-      ],
-      (err) => {
-         done(err);
-      }
+   console.log("Installing Developer Files");
+   shell.exec(
+      `docker run -v ${process.cwd()}:/app/dest digiserve/ab-code-developer:master`,
+      { silent: true }
    );
+
+   console.log("   - untaring files into developer/");
+   shell.exec(`tar -xjf developer.tar.bz2`, { silent: Options.travisCI });
+
+   console.log("   - removing tar file");
+   shell.rm("developer.tar.bz2");
+
+   done();
 }
+
+/**
+ * @function devInstallServices
+ * install all of our development services.
+ * @param {cb(err)} done
+ */
+// function devInstallServices(done) {
+//    if (!Options.develop) {
+//       done();
+//       return;
+//    }
+//    // always install these
+//    var services = ["ab_platform_web"]; // will add this later: , "ab_db"];
+
+//    async.series(
+//       [
+//          (next) => {
+//             utils.gitScanDevYML((err, list) => {
+//                if (err) {
+//                   done(err);
+//                   return;
+//                }
+//                services = services.concat(list);
+//                next();
+//             });
+//          },
+//          (next) => {
+//             // now install the repos:
+//             utils.gitInstallServices(
+//                services,
+//                { silent: Options.travisCI },
+//                next
+//             );
+//          },
+//       ],
+//       (err) => {
+//          done(err);
+//       }
+//    );
+// }
 
 /**
  * @function devInstallPlugins
  * install all of our development splugins
  * @param {cb(err)} done
  */
-function devInstallPlugins(done) {
-   if (!Options.develop) {
-      done();
-      return;
-   }
+// function devInstallPlugins(done) {
+//    if (!Options.develop) {
+//       done();
+//       return;
+//    }
 
-   // always install the ABDesigner:
-   const plugins = ["ABDesigner"];
+//    // always install the ABDesigner:
+//    const plugins = ["ABDesigner"];
 
-   async.series(
-      [
-         (next) => {
-            // now install the repos:
-            utils.gitInstallPlugins(
-               plugins,
-               { silent: Options.travisCI },
-               next
-            );
-         },
-      ],
-      (err) => {
-         done(err);
-      }
-   );
-}
+//    async.series(
+//       [
+//          (next) => {
+//             // now install the repos:
+//             utils.gitInstallPlugins(
+//                plugins,
+//                { silent: Options.travisCI },
+//                next
+//             );
+//          },
+//       ],
+//       (err) => {
+//          done(err);
+//       }
+//    );
+// }
 /*
 function devInstallServices(done) {
    var allServices = [];
@@ -415,23 +472,31 @@ async function compileUI() {
 }
 
 function configTenantAdmin(done) {
-   TenantAdmin.run(Options.tenant || {})
+   if (Options.__dbSkipped) {
+      return done();
+   }
+
+   console.log(" configuring default Tenant details");
+   var options = JSON.parse(JSON.stringify(Options.tenant || {}));
+   options.stack = Options.stack;
+   options.dbPassword = Options.dbPassword;
+   TenantAdmin.run(options)
       .then(() => {
          done();
       })
       .catch(done);
 }
 
-function initializeConfig(done) {
-   console.log();
-   console.log("initialize the configuration volumes");
-   utils
-      .configInit(Options, "config-compose.yml")
-      .then(() => {
-         done();
-      })
-      .catch(done);
-}
+// function initializeConfig(done) {
+//    console.log();
+//    console.log("initialize the configuration volumes");
+//    utils
+//       .configInit(Options, "config-compose.yml")
+//       .then(() => {
+//          done();
+//       })
+//       .catch(done);
+// }
 
 function initializeDB(done) {
    console.log();
@@ -441,7 +506,8 @@ function initializeDB(done) {
    options.keepRunning = true;
    utils
       .dbInit(options, "dbinit-compose.yml")
-      .then(() => {
+      .then((skipped) => {
+         Options.__dbSkipped = skipped;
          done();
       })
       .catch(done);
@@ -453,8 +519,16 @@ function initializeDB(done) {
  * run our db migrations from migration manager
  */
 function runDbMigrations(done) {
+   if (Options.__dbSkipped) {
+      return done();
+   }
+
    console.log();
    console.log("run db migration scripts");
-   utils.runDbMigrations(Options);
+   const params = {
+      stack: Options.stack,
+      keepRunning: true,
+   };
+   utils.runDbMigrations(params);
    return done();
 }

--- a/lib/install.js
+++ b/lib/install.js
@@ -301,9 +301,11 @@ function installDeveloperFiles(done) {
    }
 
    console.log("Installing Developer Files");
+   console.log("   - download digiserve/ab-code-developer");
+   shelljs.exec(`docker image pull digiserve/ab-code-developer:master`);
    // TODO:  return to :develop
    shell.exec(
-      `docker run -v ${process.cwd()}:/app/dest digiserve/ab-code-developer:awsready`,
+      `docker run -v ${process.cwd()}:/app/dest digiserve/ab-code-developer:master`,
       { silent: true }
    );
 

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -7,22 +7,22 @@
 //  --tag  : the docker tag of the images to run
 //
 var async = require("async");
-var fs = require("fs");
+// var fs = require("fs");
 var inquirer = require("inquirer");
+const { nanoid } = require("nanoid");
 var path = require("path");
 var utils = require(path.join(__dirname, "utils", "utils"));
-const crypto = require("crypto");
 
 var Options = {}; // the running options for this command.
 
-const GeneratedFiles = {
-   // source file :  generated file
-   "source.config-compose.yml": "config-compose.yml",
-   "source.dbinit-compose.yml": "dbinit-compose.yml",
-   "source.docker-compose.yml": "docker-compose.yml",
-   "source.docker-compose.dev.yml": "docker-compose.dev.yml",
-   "source.docker-compose.override.yml": "docker-compose.override.yml",
-};
+// const GeneratedFiles = {
+//    // source file :  generated file
+//    "source.config-compose.yml": "config-compose.yml",
+//    "source.dbinit-compose.yml": "dbinit-compose.yml",
+//    "source.docker-compose.yml": "docker-compose.yml",
+//    "source.docker-compose.dev.yml": "docker-compose.dev.yml",
+//    "source.docker-compose.override.yml": "docker-compose.override.yml",
+// };
 //
 // Build the Command
 //
@@ -151,17 +151,21 @@ Command.run = function (options) {
                });
                done();
             },
+
+            defaultValues,
             questions,
-            writeEnvironment,
-            removeGeneratedFiles,
-            generateFiles,
+
+            // writeEnvironment,
+            // removeGeneratedFiles,
+            // generateFiles,
+
             copyTemplateFiles,
             patchDockerStack,
-            setupNGINX,
-            setupSSL,
-            setupDB,
-            setupBotManager,
-            setupNotificationEmail,
+            // setupNGINX,
+            // setupSSL,
+            // setupDB,
+            // setupBotManager,
+            // setupNotificationEmail,
             developerConversion,
          ],
          (err) => {
@@ -174,6 +178,24 @@ Command.run = function (options) {
       );
    });
 };
+
+/**
+ * @function defaultValues
+ * Prepare our Options with proper values before we can ask questions.
+ * @param {cb(err)} done
+ */
+function defaultValues(done) {
+   if (!Options.authType) {
+      if (Options.casEnabled) {
+         Options.authType = "CAS";
+      }
+      if (Options.oktaEnabled) {
+         Options.authType = "OKTA";
+      }
+   }
+
+   done();
+}
 
 /**
  * @function questions
@@ -195,6 +217,10 @@ function questions(done) {
                return !values.stack && !Options.stack;
             },
          },
+
+         //
+         // Nginx
+         //
          {
             name: "port",
             type: "input",
@@ -204,6 +230,10 @@ function questions(done) {
                return !values.port && !Options.port;
             },
          },
+
+         //
+         // Database
+         //
          {
             name: "dbExpose",
             type: "confirm",
@@ -222,6 +252,15 @@ function questions(done) {
             default: 3306,
             when: (values) => {
                return values.dbExpose && !values.dbPort && !Options.dbPort;
+            },
+         },
+         {
+            name: "dbPassword",
+            type: "input",
+            message: "Enter the password for the DB Root User?",
+            default: nanoid(),
+            when: (values) => {
+               return !values.dbPassword && !Options.dbPassword;
             },
          },
          {
@@ -246,6 +285,210 @@ function questions(done) {
                return !values.tag && !Options.tag;
             },
          },
+
+         //
+         // Authentication
+         //
+         {
+            name: "authType",
+            type: "list",
+            choices: [
+               {
+                  // secure: false, ignoreTLS: true
+                  name: "login",
+                  value: "login",
+                  short: "login",
+               },
+               {
+                  // secure: false
+                  name: "CAS",
+                  value: "CAS",
+                  short: "CAS",
+               },
+               {
+                  // secure: true, requireTLS:true
+                  name: "OKTA",
+                  value: "OKTA",
+                  short: "OKTA",
+               },
+            ],
+            message: "Authentication type:",
+            default: "login",
+            when: (values) => {
+               return !values.authType && !Options.authType;
+            },
+         },
+         {
+            name: "casBaseURL",
+            type: "input",
+            message: "CAS Base Url:",
+            default: "https://my_cas.server.com/cas",
+            filter: (input) => {
+               if (input == "https://my_cas.server.com/cas") {
+                  return "";
+               }
+               return input;
+            },
+            validate: (input) => {
+               return input && input !== "https://my_cas.server.com/cas";
+            },
+            when: (values) => {
+               return (
+                  (values.authType == "CAS" || Options.authType == "CAS") &&
+                  !values.casBaseURL &&
+                  !Options.casBaseURL
+               );
+            },
+         },
+         {
+            name: "casUUIDKey",
+            type: "input",
+            message: "CAS UUID Key:",
+            default: "uuid",
+            filter: (input) => {
+               if (input == "uuid") {
+                  return "";
+               }
+               return input;
+            },
+            validate: (input) => {
+               return input && input !== "uuid";
+            },
+            when: (values) => {
+               return (
+                  (values.authType == "CAS" || Options.authType == "CAS") &&
+                  !values.casUUIDKey &&
+                  !Options.casUUIDKey
+               );
+            },
+         },
+         {
+            name: "oktaDomain",
+            type: "input",
+            message: "OKTA Domain:",
+            default: "https://my_okta.server.com",
+            filter: (input) => {
+               if (input == "https://my_okta.server.com") {
+                  return "";
+               }
+               return input;
+            },
+            validate: (input) => {
+               return input && input !== "https://my_okta.server.com";
+            },
+            when: (values) => {
+               return (
+                  (values.authType == "OKTA" || Options.authType == "OKTA") &&
+                  !values.oktaDomain &&
+                  !Options.oktaDomain
+               );
+            },
+         },
+         {
+            name: "oktaClientID",
+            type: "input",
+            message: "OKTA Client ID:",
+            when: (values) => {
+               return (
+                  (values.authType == "OKTA" || Options.authType == "OKTA") &&
+                  !values.oktaClientID &&
+                  !Options.oktaClientID
+               );
+            },
+         },
+         {
+            name: "oktaClientSecret",
+            type: "input",
+            message: "OKTA Client Secret:",
+            when: (values) => {
+               return (
+                  (values.authType == "OKTA" || Options.authType == "OKTA") &&
+                  !values.oktaClientSecret &&
+                  !Options.oktaClientSecret
+               );
+            },
+         },
+         {
+            name: "siteURL",
+            type: "input",
+            message: "Enter the URL for the auth service redirect:",
+            default: "https://this.server.com",
+            when: (values) => {
+               return (
+                  values.authType != "local" &&
+                  Options.authType != "local" &&
+                  !values.siteURL &&
+                  !Options.siteURL
+               );
+            },
+         },
+
+         //
+         // RELAY Server
+         //
+         {
+            name: "relayEnabled",
+            type: "confirm",
+            message: "Do you want to enable the RELAY service :",
+            default: false,
+            when: (values) => {
+               return (
+                  typeof values.relayEnabled == "undefined" &&
+                  typeof Options.relayEnabled == "undefined"
+               );
+            },
+         },
+         {
+            name: "relayServerURL",
+            type: "input",
+            message: "Enter the URL for the relay server:",
+            default: "https://relay.server.com",
+            filter: (input) => {
+               if (input == "https://relay.server.com") {
+                  return "";
+               }
+               return input;
+            },
+            when: (values) => {
+               return (
+                  (values.relayEnabled || Options.relayEnabled) &&
+                  !values.relayServerURL &&
+                  !Options.relayServerURL
+               );
+            },
+         },
+         {
+            name: "relayServerToken",
+            type: "input",
+            message: "Enter the relay server auth token:",
+            when: (values) => {
+               return (
+                  (values.relayEnabled || Options.relayEnabled) &&
+                  !values.relayServerToken &&
+                  !Options.relayServerToken
+               );
+            },
+         },
+         {
+            name: "pwaURL",
+            type: "input",
+            message:
+               "Enter the url to download the mobile progressive web app:",
+            default: "https://mobile.my-site.com/pwa",
+            filter: (input) => {
+               if (input == "https://mobile.my-site.com/pwa") {
+                  return "";
+               }
+               return input;
+            },
+            when: (values) => {
+               return (
+                  (values.relayEnabled || Options.relayEnabled) &&
+                  !values.pwaURL &&
+                  !Options.pwaURL
+               );
+            },
+         },
       ])
       .then((answers) => {
          for (var a in answers) {
@@ -255,7 +498,40 @@ function questions(done) {
          if (!Options.dbExpose) {
             Options.dbPort = "8899";
          }
-         // console.log("Options:", Options);
+
+         if (Options.authType != "CAS") {
+            Options.casEnabled = false;
+            Options.casBaseURL = "";
+            Options.casUUIDKey = "";
+         } else {
+            Options.casEnabled = true;
+         }
+
+         if (Options.authType != "OKTA") {
+            Options.oktaEnabled = false;
+            Options.oktaDomain = "";
+            Options.oktaClientID = "";
+            Options.oktaClientSecret = "";
+         } else {
+            Options.oktaEnabled = true;
+         }
+
+         if (Options.authType == "local") {
+            Options.siteURL = "";
+         }
+
+         if (!Options.relayEnabled) {
+            Options.relayServerURL = "";
+            Options.relayServerToken = "";
+            Options.pwaURL = "";
+         }
+
+         Options.sailsSessionSecret = nanoid(32);
+
+         Options.cypressBaseURL = `http://localhost:${Options.port ?? 80}`;
+         Options.cypressStack = Options.stack ?? "ab";
+
+         console.log("Options:", Options);
          done();
       })
       .catch(done);
@@ -265,94 +541,94 @@ function questions(done) {
  * Write to .env used in cypress. Will get overwritten if using
  * the test stack, but most of our ci runs on the main stack
  */
-async function writeEnvironment() {
-   const environment = {
-      CYPRESS_BASE_URL: `http://localhost:${Options.port ?? 80}`,
-      CYPRESS_STACK: Options.stack ?? "ab",
-   };
-   utils.writeEnvironment(environment);
-   return;
-}
+// async function writeEnvironment() {
+//    const environment = {
+//       CYPRESS_BASE_URL: `http://localhost:${Options.port ?? 80}`,
+//       CYPRESS_STACK: Options.stack ?? "ab",
+//    };
+//    utils.writeEnvironment(environment);
+//    return;
+// }
 
 /**
  * @function removeGeneratedFiles
  * Remove any generated files
  * @param {cb(err)} done
  */
-function removeGeneratedFiles(done) {
-   var generatedFiles = Object.keys(GeneratedFiles).map((k) => {
-      return GeneratedFiles[k];
-   });
-   var cwd = process.cwd();
-   async.each(
-      generatedFiles,
-      (file, cb) => {
-         var pathFile = path.join(cwd, file);
-         fs.unlink(pathFile, (err) => {
-            if (err) {
-               // console.log(err);
-            }
-            cb();
-         });
-      },
-      (err) => {
-         done(err);
-      }
-   );
-}
+// function removeGeneratedFiles(done) {
+//    var generatedFiles = Object.keys(GeneratedFiles).map((k) => {
+//       return GeneratedFiles[k];
+//    });
+//    var cwd = process.cwd();
+//    async.each(
+//       generatedFiles,
+//       (file, cb) => {
+//          var pathFile = path.join(cwd, file);
+//          fs.unlink(pathFile, (err) => {
+//             if (err) {
+//                // console.log(err);
+//             }
+//             cb();
+//          });
+//       },
+//       (err) => {
+//          done(err);
+//       }
+//    );
+// }
 
 /**
  * @function generateFiles
  * generate files
  * @param {cb(err)} done
  */
-function generateFiles(done) {
-   var sourceFiles = Object.keys(GeneratedFiles);
-   var cwd = process.cwd();
+// function generateFiles(done) {
+//    var sourceFiles = Object.keys(GeneratedFiles);
+//    var cwd = process.cwd();
 
-   var nonExposeDBTag = /\s{2}db:\n\s*ports:\s*\n\s*-/;
-   var nonExposeDBReplace = `  # db:
-    # ports:
-    #   -`;
+//    var nonExposeDBTag = /\s{2}db:\n\s*ports:\s*\n\s*-/;
+//    var nonExposeDBReplace = `  # db:
+//     # ports:
+//     #   -`;
 
-   if (Options.develop) {
-      Options.configImage = "node";
-      Options.configBind = `
-      - type: bind
-        source: ./developer/config
-        target: /app
-`;
-   } else {
-      // TODO: replace this with the actual service image
-      Options.configImage = `digiserve/ab-config:${Options.tag}`;
-      Options.configBind = "";
-   }
+//    if (Options.develop) {
+//       Options.configImage = "node";
+//       Options.configBind = `
+//       - type: bind
+//         source: ./developer/config
+//         target: /app
+// `;
+//    } else {
+//       // TODO: replace this with the actual service image
+//       Options.configImage = `digiserve/ab-config:${Options.tag}`;
+//       Options.configBind = "";
+//    }
 
-   async.each(
-      sourceFiles,
-      (file, cb) => {
-         // render the source files
-         var pathSourceFile = path.join(cwd, file);
-         var contents = utils.fileRender(pathSourceFile, Options);
+//    async.each(
+//       sourceFiles,
+//       (file, cb) => {
+//          // render the source files
+//          var pathSourceFile = path.join(cwd, file);
+//          var contents = utils.fileRender(pathSourceFile, Options);
 
-         if (!Options.dbExpose) {
-            contents = contents.replace(nonExposeDBTag, nonExposeDBReplace);
-         }
+//          if (!Options.dbExpose) {
+//             contents = contents.replace(nonExposeDBTag, nonExposeDBReplace);
+//          }
 
-         // write them to the destination files
-         var pathFile = path.join(cwd, GeneratedFiles[file]);
-         fs.writeFile(pathFile, contents, (err) => {
-            if (err) {
-               console.log(err);
-            }
-            cb(err);
-         });
-      },
-      (err) => {
-         done(err);
-      }
-   );
-}
+//          // write them to the destination files
+//          var pathFile = path.join(cwd, GeneratedFiles[file]);
+//          fs.writeFile(pathFile, contents, (err) => {
+//             if (err) {
+//                console.log(err);
+//             }
+//             cb(err);
+//          });
+//       },
+//       (err) => {
+//          done(err);
+//       }
+//    );
+// }
 
 /**
  * @function copyTemplateFiles
@@ -360,19 +636,7 @@ function generateFiles(done) {
  * @param {cb(err)} done
  */
 function copyTemplateFiles(done) {
-   let secret = "";
-   // A random session secret to add to local.js
-   try {
-      secret = crypto.randomBytes(16).toString("hex");
-   } catch (err) {
-      console.warn("Error generating session secret", err);
-   }
-   utils.fileCopyTemplates(
-      "setup",
-      { stack: Options.stack, secret, develop: Options.develop ?? false },
-      [],
-      done
-   );
+   utils.fileCopyTemplates("setup", Options, [], done);
 }
 
 /**
@@ -400,50 +664,51 @@ function patchDockerStack(done) {
                Options.stack || "ab"
             }`,
          },
-         {
-            file: path.join(process.cwd(), "cli.sh"),
-            tag: /ab_/g,
-            replace: `${Options.stack || "ab"}_`,
-            log: `    Docker Stack: logs.js => ${Options.stack || "ab"}`,
-         },
-         {
-            file: path.join(process.cwd(), "dockerImageUpdate.js"),
-            tag: / ab/g,
-            replace: ` ${Options.stack || "ab"}`,
-            log: `    Docker Stack: dockerImageUpate.js => ${
-               Options.stack || "ab"
-            }`,
-         },
-         {
-            file: path.join(process.cwd(), "Down.sh"),
-            tag: / ab/g,
-            replace: ` ${Options.stack || "ab"}`,
-            log: `    Docker Stack: Down.sh => ${Options.stack || "ab"}`,
-         },
-         {
-            file: path.join(process.cwd(), "logs.js"),
-            tag: /ab_/g,
-            replace: `${Options.stack || "ab"}_`,
-            log: `    Docker Stack: logs.js => ${Options.stack || "ab"}`,
-         },
-         {
-            file: path.join(process.cwd(), "UP.sh"),
-            tag: / ab/g,
-            replace: ` ${Options.stack || "ab"}`,
-            log: `    Docker Stack: UP.sh => ${Options.stack || "ab"}`,
-         },
-         {
-            file: path.join(process.cwd(), "configReset.sh"),
-            tag: / ab/g,
-            replace: ` ${Options.stack || "ab"}`,
-            log: `    Docker Stack: configReset.sh => ${Options.stack || "ab"}`,
-         },
-         {
-            file: path.join(process.cwd(), "testReset.sh"),
-            tag: /_ab/g,
-            replace: `_${Options.stack || "ab"}`,
-            log: `    Docker Stack: testReset.sh => ${Options.stack || "ab"}`,
-         },
+         // {
+         //    file: path.join(process.cwd(), "cli.sh"),
+         //    tag: /ab_/g,
+         //    replace: `${Options.stack || "ab"}_`,
+         //    log: `    Docker Stack: logs.js => ${Options.stack || "ab"}`,
+         // },
+         // {
+         //    file: path.join(process.cwd(), "dockerImageUpdate.js"),
+         //    tag: / ab/g,
+         //    replace: ` ${Options.stack || "ab"}`,
+         //    log: `    Docker Stack: dockerImageUpate.js => ${
+         //       Options.stack || "ab"
+         //    }`,
+         // },
+         // {
+         //    file: path.join(process.cwd(), "Down.sh"),
+         //    tag: / ab/g,
+         //    replace: ` ${Options.stack || "ab"}`,
+         //    log: `    Docker Stack: Down.sh => ${Options.stack || "ab"}`,
+         // },
+         // {
+         //    file: path.join(process.cwd(), "logs.js"),
+         //    tag: /ab_/g,
+         //    replace: `${Options.stack || "ab"}_`,
+         //    log: `    Docker Stack: logs.js => ${Options.stack || "ab"}`,
+         // },
+         // {
+         //    file: path.join(process.cwd(), "UP.sh"),
+         //    tag: / ab/g,
+         //    replace: ` ${Options.stack || "ab"}`,
+         //    log: `    Docker Stack: UP.sh => ${Options.stack || "ab"}`,
+         // },
+         // {
+         //    file: path.join(process.cwd(), "configReset.sh"),
+         //    tag: / ab/g,
+         //    replace: ` ${Options.stack || "ab"}`,
+         //    log: `    Docker Stack: configReset.sh => ${Options.stack || "ab"}`,
+         // },
+         // {
+         //    file: path.join(process.cwd(), "testReset.sh"),
+         //    tag: /_ab/g,
+         //    replace: `_${Options.stack || "ab"}`,
+         //    log: `    Docker Stack: testReset.sh => ${Options.stack || "ab"}`,
+         // },
+
          // {
          //    file: path.join(process.cwd(), "/test/e2e/cypress.ab_runtime.json"),
          //    tag: /test_ab/g,
@@ -477,17 +742,17 @@ function patchDockerStack(done) {
          //       Options.stack || "ab"
          //    }`,
          // },
-         {
-            file: path.join(
-               process.cwd(),
-               `${Options.stack}_system_monitor.js`
-            ),
-            tag: /"ab"/g,
-            replace: `"${Options.stack || "ab"}"`,
-            log: `    Docker Stack: ${Options.stack}_system_monitor.js => ${
-               Options.stack || "ab"
-            }`,
-         },
+         // {
+         //    file: path.join(
+         //       process.cwd(),
+         //       `${Options.stack}_system_monitor.js`
+         //    ),
+         //    tag: /"ab"/g,
+         //    replace: `"${Options.stack || "ab"}"`,
+         //    log: `    Docker Stack: ${Options.stack}_system_monitor.js => ${
+         //       Options.stack || "ab"
+         //    }`,
+         // },
       ],
       done
    );
@@ -498,137 +763,137 @@ function patchDockerStack(done) {
  * run the nginx setup command.
  * @param {cb(err)} done
  */
-function setupNGINX(done) {
-   Options.nginxEnable = true;
-   done();
-}
+// function setupNGINX(done) {
+//    Options.nginxEnable = true;
+//    done();
+// }
 
 /**
  * @function setupSSL
  * run the ssl setup command.
  * @param {cb(err)} done
  */
-function setupSSL(done) {
-   if (!Options.nginxEnable) done();
+// function setupSSL(done) {
+//    if (!Options.nginxEnable) done();
 
-   var sslCommand = require(path.join(__dirname, "ssl.js"));
+//    var sslCommand = require(path.join(__dirname, "ssl.js"));
 
-   // scan Options for ssl related options:
-   // "ssl.self"
-   // "ssl.pathKey ssl.pathCert"
-   // "ssl.none"
-   var sslOptions = Options.ssl || {};
-   for (var o in Options) {
-      var parts = o.split(".");
-      if (parts[0] == "ssl" && parts[1]) {
-         sslOptions[parts[1]] = Options[o];
-      }
-   }
+//    // scan Options for ssl related options:
+//    // "ssl.self"
+//    // "ssl.pathKey ssl.pathCert"
+//    // "ssl.none"
+//    var sslOptions = Options.ssl || {};
+//    for (var o in Options) {
+//       var parts = o.split(".");
+//       if (parts[0] == "ssl" && parts[1]) {
+//          sslOptions[parts[1]] = Options[o];
+//       }
+//    }
 
-   sslCommand.run(sslOptions).then(done).catch(done);
-}
+//    sslCommand.run(sslOptions).then(done).catch(done);
+// }
 
 /**
  * @function setupBotManager
  * run the configBotManager setup command.
  * @param {cb(err)} done
  */
-function setupBotManager(done) {
-   var botManagerCommand = require(path.join(
-      __dirname,
-      "tasks",
-      "configBotManager.js"
-   ));
+// function setupBotManager(done) {
+//    var botManagerCommand = require(path.join(
+//       __dirname,
+//       "tasks",
+//       "configBotManager.js"
+//    ));
 
-   // scan Options for bot_manager related options:
-   // "bot.dhEnabled, bot.dhPort"
-   // "bot.botEnable, bot.botToken, bot.botName, bot.slackChannel"
-   // "bot.hosttcpport"
-   var botOptions = {
-      dhEnable: false,
-      dhPort: 14000,
-      dockerTag: Options.tag,
-   };
+//    // scan Options for bot_manager related options:
+//    // "bot.dhEnabled, bot.dhPort"
+//    // "bot.botEnable, bot.botToken, bot.botName, bot.slackChannel"
+//    // "bot.hosttcpport"
+//    var botOptions = {
+//       dhEnable: false,
+//       dhPort: 14000,
+//       dockerTag: Options.tag,
+//    };
 
-   // capture any existing .bot values:
-   if (Options.bot) {
-      for (var b in Options.bot) {
-         botOptions[b] = Options.bot[b];
-      }
-   }
+//    // capture any existing .bot values:
+//    if (Options.bot) {
+//       for (var b in Options.bot) {
+//          botOptions[b] = Options.bot[b];
+//       }
+//    }
 
-   // find any possible "bot.param" values
-   for (var o in Options) {
-      var parts = o.split(".");
-      if (parts[0] == "bot" && parts[1]) {
-         botOptions[parts[1]] = Options[o];
-      }
-   }
-   botOptions.stack = Options.stack;
-   console.log("botOptions", botOptions);
+//    // find any possible "bot.param" values
+//    for (var o in Options) {
+//       var parts = o.split(".");
+//       if (parts[0] == "bot" && parts[1]) {
+//          botOptions[parts[1]] = Options[o];
+//       }
+//    }
+//    botOptions.stack = Options.stack;
+//    console.log("botOptions", botOptions);
 
-   botManagerCommand.run(botOptions).then(done).catch(done);
-}
+//    botManagerCommand.run(botOptions).then(done).catch(done);
+// }
 
 /**
  * @function setupDB
  * run the configDB setup command.
  * @param {cb(err)} done
  */
-function setupDB(done) {
-   var configDBCommand = require(path.join(__dirname, "tasks", "configDB.js"));
+// function setupDB(done) {
+//    var configDBCommand = require(path.join(__dirname, "tasks", "configDB.js"));
 
-   // scan Options for db related options:
-   // "db.password
-   var dbOptions = {};
+//    // scan Options for db related options:
+//    // "db.password
+//    var dbOptions = {};
 
-   // capture any existing .db values:
-   if (Options.db) {
-      for (var b in Options.db) {
-         dbOptions[b] = Options.db[b];
-      }
-   }
+//    // capture any existing .db values:
+//    if (Options.db) {
+//       for (var b in Options.db) {
+//          dbOptions[b] = Options.db[b];
+//       }
+//    }
 
-   // find any possible "db.param" values
-   for (var o in Options) {
-      var parts = o.split(".");
-      if (parts[0] == "db") {
-         dbOptions[parts[1]] = Options[o];
-      }
-   }
+//    // find any possible "db.param" values
+//    for (var o in Options) {
+//       var parts = o.split(".");
+//       if (parts[0] == "db") {
+//          dbOptions[parts[1]] = Options[o];
+//       }
+//    }
 
-   configDBCommand.run(dbOptions).then(done).catch(done);
-}
+//    configDBCommand.run(dbOptions).then(done).catch(done);
+// }
 
 /**
  * @function setupNotificationEmail
  * run the configNotificationEmail setup command.
  * @param {cb(err)} done
  */
-function setupNotificationEmail(done) {
-   var notificationEmailCommand = require(path.join(
-      __dirname,
-      "tasks",
-      "configNotificationEmail.js"
-   ));
+// function setupNotificationEmail(done) {
+//    var notificationEmailCommand = require(path.join(
+//       __dirname,
+//       "tasks",
+//       "configNotificationEmail.js"
+//    ));
 
-   // scan Options for smtp related options:
-   // smtp.smtpEnabled
-   // smtp.smtpHost,
-   // smtp.smtpTLS
-   // smtp.smtpPort
-   // smtp.smtpAuth, smtp.smtpAuthUser, smtp.smtpAuthPass
-   var emailOptions = Options.smtp || {};
+//    // scan Options for smtp related options:
+//    // smtp.smtpEnabled
+//    // smtp.smtpHost,
+//    // smtp.smtpTLS
+//    // smtp.smtpPort
+//    // smtp.smtpAuth, smtp.smtpAuthUser, smtp.smtpAuthPass
+//    var emailOptions = Options.smtp || {};
 
-   for (var o in Options) {
-      var parts = o.split(".");
-      if (parts[0] == "smtp" && parts[1]) {
-         emailOptions[parts[1]] = Options[o];
-      }
-   }
+//    for (var o in Options) {
+//       var parts = o.split(".");
+//       if (parts[0] == "smtp" && parts[1]) {
+//          emailOptions[parts[1]] = Options[o];
+//       }
+//    }
 
-   notificationEmailCommand.run(emailOptions).then(done).catch(done);
-}
+//    notificationEmailCommand.run(emailOptions).then(done).catch(done);
+// }
 
 /**
  * @function developerConversion

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -531,11 +531,7 @@ function questions(done) {
          Options.cypressBaseURL = `http://localhost:${Options.port ?? 80}`;
          Options.cypressStack = Options.stack ?? "ab";
 
-         // TODO: this is for testing our awsReady branch before it goes main stream.
-         // Remove this when merging into Develop:
-         Options.tag = "awsready";
-
-         console.log("Options:", Options);
+         // console.log("Options:", Options);
          done();
       })
       .catch(done);

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -531,6 +531,10 @@ function questions(done) {
          Options.cypressBaseURL = `http://localhost:${Options.port ?? 80}`;
          Options.cypressStack = Options.stack ?? "ab";
 
+         // TODO: this is for testing our awsReady branch before it goes main stream.
+         // Remove this when merging into Develop:
+         Options.tag = "awsready";
+
          console.log("Options:", Options);
          done();
       })

--- a/lib/tasks/configNotificationEmail.js
+++ b/lib/tasks/configNotificationEmail.js
@@ -81,8 +81,11 @@ function checkDependencies(done) {
  */
 function pullExistingConfigSettings(done) {
    try {
-      Config = require(path.join(process.cwd(), "config", "local.js"))
-         .notification_email;
+      Config = require(path.join(
+         process.cwd(),
+         "config",
+         "local.js"
+      )).notification_email;
    } catch (e) {
       Config = {};
    }
@@ -150,8 +153,7 @@ function questions(done) {
                         },
                         {
                            // secure: false
-                           name:
-                              "Use if server supports it (STARTTLS extension)",
+                           name: "Use if server supports it (STARTTLS extension)",
                            value: "serverSupport",
                            short: "server support",
                         },

--- a/lib/tasks/configTenantAdmin.js
+++ b/lib/tasks/configTenantAdmin.js
@@ -6,9 +6,11 @@
 //
 //
 const async = require("async");
+const fs = require("fs");
 const inquirer = require("inquirer");
 const { nanoid } = require("nanoid");
 const path = require("path");
+const shell = require("shelljs");
 const utils = require(path.join(__dirname, "..", "utils", "utils"));
 
 var Options = {}; // the running options for this command.
@@ -47,8 +49,10 @@ Command.run = function (options) {
                done();
             },
             questions,
+            createUpdateCommand,
+            updateCommand,
+            removeTempFiles,
             writeEnvironment,
-            updateSQLInsert,
          ],
          (err) => {
             if (err) {
@@ -127,17 +131,67 @@ function questions(done) {
 }
 
 /**
+ * @function createUpdateCommand
+ * create the UPDATE command for the Tenant Admin
+ * @param {cb(err)} done
+ */
+function createUpdateCommand(done) {
+   const pathTemplate = path.join(utils.fileTemplatePath(), "_cmd_tenant.sql");
+   Options.uuid = utils.uuid();
+   const contents = utils.fileRender(pathTemplate, Options);
+   fs.writeFileSync("cmd_tenant.sql", contents);
+   done();
+}
+
+/**
+ * @function updateCommand
+ * run the UPDATE command inside the container:
+ * @param {cb(err)} done
+ */
+function updateCommand(done) {
+   // figure out the running container ID
+   const cmd = `docker ps | grep ${Options.stack}_db | awk '{ print $1 }'`;
+   const containerID = shell.exec(cmd).stdout.replace("\n", "");
+
+   // run the command
+   let cmd2 = `docker exec -i ${containerID} mysql -uroot -p${Options.dbPassword} "appbuilder-admin" < cmd_tenant.sql`;
+   // console.log(`command2[${cmd2}]`);
+   let output = shell.exec(cmd2).stdout;
+   console.log(output);
+   done();
+}
+
+/**
+ * @function removeTempFiles
+ * remove any of the temp files created for the update
+ * @param {cb(err)} done
+ */
+function removeTempFiles(done) {
+   shell.rm("cmd_tenant.sql");
+   done();
+}
+
+/**
+ * @function writeEnvironment()
  * Write to .env used in cypress. Will get overwritten if using
  * the test stack, but most of our ci runs on the main stack
  */
-async function writeEnvironment() {
-   const environment = {
-      CYPRESS_TENANT: `admin`,
-      CYPRESS_USER_EMAIL: Options.email,
-      CYPRESS_USER_PASSWORD: Options.password,
-   };
-   utils.writeEnvironment(environment);
-   return;
+function writeEnvironment(done) {
+   let patches = [
+      {
+         file: path.join(process.cwd(), ".env"),
+         tag: /Cypress Settings.*\n.*##/,
+         replace: `Cypress Settings
+##
+CYPRESS_TENANT="admin"
+CYPRESS_USER_EMAIL="${Options.email}"
+CYPRESS_USER_PASSWORD="${Options.password}"
+`,
+      },
+   ];
+   utils.filePatch(patches, (err) => {
+      done(err);
+   });
 }
 
 /**
@@ -145,42 +199,67 @@ async function writeEnvironment() {
  * update the TenantManager.sql data with the tenant admin user
  * @param {cb(err)} done
  */
-function updateSQLInsert(done) {
-   var adminUUID = utils.uuid();
-   var patches = [
-      {
-         file: path.join(
-            process.cwd(),
-            "mysql",
-            "init",
-            "02-tenant_manager.sql"
-         ),
-         tag: /##admin-url##/g, // <-- Global
-         replace: Options.url,
-         log: "patching: 02-tenant_manager.sql connect URL to Tenant(Admin)",
-      },
-      {
-         file: path.join(process.cwd(), "mysql", "init", "03-site_tables.sql"),
-         tag: "# Insert site_user Data #",
-         template: "_03-siteUser.sql",
-         data: {
-            uuid: adminUUID,
-            username: Options.username,
-            password: Options.hashedPassword,
-            salt: Options.salt,
-            email: Options.email,
-         },
-         log: "patching: 03-site_tables.sql with Tenant Admin Settings",
-      },
-      {
-         file: path.join(process.cwd(), "mysql", "init", "03-site_tables.sql"),
-         tag: /##admin-username##/g, // <-- Global
-         replace: Options.username,
-         log: "patching: 03-site_tables.sql connect Role(System Admin) to User(Admin)",
-      },
-   ];
+// function updateSQLInsert(done) {
+//    var adminUUID = utils.uuid();
+//    var patches = [
+//       {
+//          file: path.join(
+//             process.cwd(),
+//             "mysql",
+//             "init",
+//             "02-tenant_manager.sql"
+//          ),
+//          tag: /##admin-url##/g, // <-- Global
+//          replace: Options.url,
+//          log: "patching: 02-tenant_manager.sql connect URL to Tenant(Admin)",
+//       },
+//       {
+//          file: path.join(process.cwd(), "mysql", "init", "03-site_tables.sql"),
+//          tag: "# Insert site_user Data #",
+//          template: "_03-siteUser.sql",
+//          data: {
+//             uuid: adminUUID,
+//             username: Options.username,
+//             password: Options.hashedPassword,
+//             salt: Options.salt,
+//             email: Options.email,
+//          },
+//          log: "patching: 03-site_tables.sql with Tenant Admin Settings",
+//       },
+//       {
+//          file: path.join(process.cwd(), "mysql", "init", "03-site_tables.sql"),
+//          tag: /##admin-username##/g, // <-- Global
+//          replace: Options.username,
+//          log: "patching: 03-site_tables.sql connect Role(System Admin) to User(Admin)",
+//       },
+//    ];
+//    utils.filePatch(patches, (err) => {
+//       done(err);
+//    });
+// }
 
-   utils.filePatch(patches, (err) => {
-      done(err);
-   });
-}
+/**
+ * @function updateTestConfig
+ * update the test/setup/config.js with the Tenant Admin Login info
+ * @param {cb(err)} done
+ */
+// function updateTestConfig(done) {
+//    var patches = [
+//       {
+//          file: path.join(process.cwd(), "test", "setup", "config.js"),
+//          tag: "[email]",
+//          replace: Options.email,
+//          log: "patching: ./test/setup/config.js with Tenant Admin Settings (email)",
+//       },
+//       {
+//          file: path.join(process.cwd(), "test", "setup", "config.js"),
+//          tag: "[password]",
+//          replace: Options.password,
+//          log: "patching: ./test/setup/config.js with Tenant Admin Settings (email)",
+//       },
+//    ];
+
+//    utils.filePatch(patches, (err) => {
+//       done(err);
+//    });
+// }

--- a/lib/tasks/configTenantAdmin.js
+++ b/lib/tasks/configTenantAdmin.js
@@ -185,8 +185,7 @@ function writeEnvironment(done) {
 ##
 CYPRESS_TENANT="admin"
 CYPRESS_USER_EMAIL="${Options.email}"
-CYPRESS_USER_PASSWORD="${Options.password}"
-`,
+CYPRESS_USER_PASSWORD="${Options.password}"`,
       },
    ];
    utils.filePatch(patches, (err) => {

--- a/lib/tasks/serviceNew.js
+++ b/lib/tasks/serviceNew.js
@@ -250,10 +250,10 @@ function installABPlatform(done) {
                   }
                );
             },
-            // make sure knex & objection are installed.
+            // make sure any npm modules are installed
             (next) => {
                process.chdir(dirName);
-               utils.execCli("npm install knex objection --save");
+               utils.execCli("npm install");
                process.chdir(cwd);
                next();
             },

--- a/lib/utils/dbInit.js
+++ b/lib/utils/dbInit.js
@@ -54,7 +54,7 @@ module.exports = function (Options, dbinitFileName = "dbinit-compose.yml") {
                // check for existing mysql_data volume
                existingVolume = shell
                   .exec(`docker volume ls`, { silent: true })
-                  .grep(dataVolume)
+                  .grep(` ${dataVolume}`)
                   .stdout.replace(/\n*\r*/g, "");
                if (existingVolume == "") {
                   return done();

--- a/lib/utils/dbInit.js
+++ b/lib/utils/dbInit.js
@@ -126,7 +126,7 @@ module.exports = function (Options, dbinitFileName = "dbinit-compose.yml") {
                done();
             },
             (done) => {
-               if (existingVolume == "" || Options.dbVolume == "keep") {
+               if (existingVolume == "" || skipInstall) {
                   return done();
                }
 
@@ -165,7 +165,7 @@ module.exports = function (Options, dbinitFileName = "dbinit-compose.yml") {
             if (err) {
                return reject(err);
             }
-            return resolve();
+            return resolve(skipInstall);
          }
       );
    });

--- a/lib/utils/dockerStackWatch.js
+++ b/lib/utils/dockerStackWatch.js
@@ -87,6 +87,15 @@ module.exports = function (
                         silent: true,
                      }
                   );
+
+                  // This was giving us problems on windows, docker v23.xxx
+                  // remove the "name: {stack}" from the delme.yml:
+                  shelljs.exec(
+                     `grep -v ^name:.${stack} delme.yml > temp && mv temp delme.yml`,
+                     {
+                        silent: true,
+                     }
+                  );
                   var response;
                   if (process.arch == "arm64") {
                      // for Apple M1 chip, use docker-compose instead.
@@ -140,12 +149,15 @@ module.exports = function (
                   check(context, done, 1);
                }, intervalCheck);
 
-               var command = path.join(process.cwd(), "logs.js");
-               var options = [];
-               if (os.platform() == "win32") {
-                  options.push(command);
-                  command = "node";
-               }
+               // var command = path.join(process.cwd(), "logs.js");
+               // var options = [];
+               // if (true || os.platform() == "win32") {
+               //    options.push(command);
+               //    command = "node";
+               // }
+               // #Fix: seems like this is more stable across platforms
+               var command = "node";
+               var options = [path.join(process.cwd(), "logs.js")];
 
                execCommand({
                   command,

--- a/lib/utils/dockerStackWatch.js
+++ b/lib/utils/dockerStackWatch.js
@@ -87,12 +87,22 @@ module.exports = function (
                         silent: true,
                      }
                   );
-                  var response = shelljs.exec(
-                     `docker stack deploy -c delme.yml ${stack}`,
-                     {
-                        silent: true,
-                     }
-                  );
+                  var response;
+                  if (process.arch == "arm64") {
+                     // for Apple M1 chip, use docker-compose instead.
+                     // 1 June 2023: getting an error when running our ab-db container:
+                     // no suitable node (unsupported platform on 1 node)
+                     response = shelljs.exec(`docker-compose -f delme.yml up`, {
+                        // silent: true,
+                     });
+                  } else {
+                     response = shelljs.exec(
+                        `docker stack deploy -c delme.yml ${stack}`,
+                        {
+                           silent: true,
+                        }
+                     );
+                  }
                   if (response.code == 0) {
                      done();
                   } else {

--- a/lib/utils/dockerStackWatch.js
+++ b/lib/utils/dockerStackWatch.js
@@ -93,7 +93,7 @@ module.exports = function (
                      // 1 June 2023: getting an error when running our ab-db container:
                      // no suitable node (unsupported platform on 1 node)
                      response = shelljs.exec(
-                        `docker-compose -d -f delme.yml up`,
+                        `docker-compose -f delme.yml up -d`,
                         {
                            // silent: true,
                         }

--- a/lib/utils/dockerStackWatch.js
+++ b/lib/utils/dockerStackWatch.js
@@ -92,9 +92,12 @@ module.exports = function (
                      // for Apple M1 chip, use docker-compose instead.
                      // 1 June 2023: getting an error when running our ab-db container:
                      // no suitable node (unsupported platform on 1 node)
-                     response = shelljs.exec(`docker-compose -f delme.yml up`, {
-                        // silent: true,
-                     });
+                     response = shelljs.exec(
+                        `docker-compose -d -f delme.yml up`,
+                        {
+                           // silent: true,
+                        }
+                     );
                   } else {
                      response = shelljs.exec(
                         `docker stack deploy -c delme.yml ${stack}`,

--- a/lib/utils/dockerStackWatch.js
+++ b/lib/utils/dockerStackWatch.js
@@ -80,8 +80,15 @@ module.exports = function (
                // create a docker process for initializing the DB
                console.log(`... booting up ${composeFileName}`);
                var tryIt = () => {
+                  // use config to resolve any .env variables into a usable config
+                  shelljs.exec(
+                     `docker-compose -f ${composeFileName} config > delme.yml`,
+                     {
+                        silent: true,
+                     }
+                  );
                   var response = shelljs.exec(
-                     `docker stack deploy -c ${composeFileName} ${stack}`,
+                     `docker stack deploy -c delme.yml ${stack}`,
                      {
                         silent: true,
                      }

--- a/lib/utils/gitInstallServices.js
+++ b/lib/utils/gitInstallServices.js
@@ -21,18 +21,19 @@ var checkTime = 2 * 60 * 1000; // 2 min
 
 var nodeVersion = "node"; // "node:14.9";
 function checkDocker() {
-   shell.exec(`docker ps`, { async: true, silent: true }, (
-      code,
-      stdout /* , stderr */
-   ) => {
-      // console.log("checkDocker(): stdout", stdout);
-      if (stdout.indexOf(` ${nodeVersion} `) == -1) {
-         console.log(
-            "... docker did not seem to start the node container. If this persists, try restarting docker Desktop."
-         );
-         checkID = setTimeout(checkDocker, checkTime);
+   shell.exec(
+      `docker ps`,
+      { async: true, silent: true },
+      (code, stdout /* , stderr */) => {
+         // console.log("checkDocker(): stdout", stdout);
+         if (stdout.indexOf(` ${nodeVersion} `) == -1) {
+            console.log(
+               "... docker did not seem to start the node container. If this persists, try restarting docker Desktop."
+            );
+            checkID = setTimeout(checkDocker, checkTime);
+         }
       }
-   });
+   );
 }
 
 function ProcessData(context, data) {
@@ -133,9 +134,11 @@ module.exports = function (allServices = [], options = {}, done) {
    // these possible repos
    var specialCases = [
       "ab_platform_web",
-      "app_builder",
-      "appdev-opsportal",
-      "appdev-core",
+      "ab_db",
+      "ab_web",
+      // "app_builder",
+      // "appdev-opsportal",
+      // "appdev-core",
    ];
 
    var oldURLs = ["app_builder", "appdev-opsportal", "appdev-core"];

--- a/lib/utils/runDbMigrations.js
+++ b/lib/utils/runDbMigrations.js
@@ -11,8 +11,11 @@ const shelljs = require("shelljs");
  * @param {object} options
  */
 module.exports = function ({ stack, keepRunning /*, tag */ }) {
-   const tag = "awsready"; // only have the master tag built currently
+   const tag = "master"; // only have the master tag built currently
    const network = `${stack}_default`;
+
+   console.log("   - pulling latest migration-manager");
+   shelljs.exec(`docker image pull digiserve/ab-migration-manager:${tag}`);
 
    shelljs.exec(
       `docker run --env-file .env --network=${network} digiserve/ab-migration-manager:${tag} node app.js`

--- a/lib/utils/runDbMigrations.js
+++ b/lib/utils/runDbMigrations.js
@@ -4,19 +4,18 @@
 //
 //
 const shelljs = require("shelljs");
-const path = require("path");
+// const path = require("path");
 /**
  * run the db migrations (using ab migration manager).
  * Note: expects the options.stack to be running with db conatiner.
  * @param {object} options
  */
 module.exports = function ({ stack, keepRunning /*, tag */ }) {
-   const tag = "master"; // only have the master tag built currently
+   const tag = "awsready"; // only have the master tag built currently
    const network = `${stack}_default`;
-   const pathConfig = path.join(process.cwd(), "/config/local.js");
 
    shelljs.exec(
-      `docker run -v ${pathConfig}:/app/config/local.js --network=${network} digiserve/ab-migration-manager:${tag} node app.js`
+      `docker run --env-file .env --network=${network} digiserve/ab-migration-manager:${tag} node app.js`
    );
 
    if (!keepRunning) {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
       "test": "npm run lint && npm run custom-tests && echo 'Done'",
       "lint": "eslint --fix . && echo '✅ Your .js files look good.'",
       "custom-tests": "echo '(no custom tests yet)'",
-      "ci:dev-install": "node index.js install ab-test --develop --port=80 --tag=develop --nginx.enable=true --ssl.none --bot.enable=false --smtp.enable=false --db.expose=false --db.password=root --db.encryption=false --stack=ab --tenant.username=admin --tenant.password=admin --tenant.email=neo@thematrix.com --tenant.url=http://localhost:80"
+      "ci:dev-install": "node index.js install ab --stack=ab --develop --port=80 --tag=develop --dbExpose=true --dbPort=8888 --dbPassword=root --authType=login --relayEnabled=false --siteURL=http://localhost:80 --tenant.username=admin --tenant.password=admin --tenant.email=admin@email.com --tenant.url=http://localhost:80"
    }
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
    "scripts": {
       "test": "npm run lint && npm run custom-tests && echo 'Done'",
       "lint": "eslint --fix . && echo '✅ Your .js files look good.'",
-      "custom-tests": "echo '(no custom tests yet)'",
-      "ci:dev-install": "node index.js install ab --stack=ab --develop --port=80 --tag=develop --dbExpose=true --dbPort=8888 --dbPassword=root --authType=login --relayEnabled=false --siteURL=http://localhost:80 --tenant.username=admin --tenant.password=admin --tenant.email=admin@email.com --tenant.url=http://localhost:80"
+      "custom-tests": "echo '(no custom tests yet)'"
    }
 }

--- a/templates/_cmd_tenant.sql
+++ b/templates/_cmd_tenant.sql
@@ -1,0 +1,30 @@
+
+
+SET FOREIGN_KEY_CHECKS=0;
+
+UPDATE SITE_USER
+SET
+  username="<%= username %>",
+  password="<%= hashedPassword %>",
+  salt="<%= salt %>",
+  email="<%= email %>",
+  uuid="<%= uuid %>"
+WHERE
+  uuid="060fa9f0-df67-42fe-bf52-34f7014beb65";
+/*!40000 ALTER TABLE `SITE_USER` ENABLE KEYS */;
+
+
+UPDATE AB_JOINMN_ROLE_USER_users
+SET
+  USER="<%= username %>"
+WHERE
+  USER="admin";
+
+
+UPDATE SITE_SCOPE
+SET
+  createdBy="<%= username %>"
+WHERE
+  createdBy="admin";
+
+SET FOREIGN_KEY_CHECKS=1;

--- a/templates/_dbinit-compose.yml
+++ b/templates/_dbinit-compose.yml
@@ -1,0 +1,23 @@
+version: "3.2"
+volumes:
+  mysql_data:
+
+networks:
+  default:
+    attachable: true
+
+services:
+  #db: use Maria DB as our backend DB
+  db:
+    image: docker.io/digiserve/ab-db:$AB_DB_VERSION
+    environment:
+      MYSQL_ROOT_PASSWORD: $MYSQL_PASSWORD
+    volumes:
+      - mysql_data:/var/lib/mysql
+    # on windows: use this command. (be sure to clear out mysql/data folder)
+    # command: mysqld --innodb-flush-method=littlesync --innodb-use-native-aio=OFF --log_bin=ON
+    ######
+    # when there is a problem with : Error: ER_CRASHED_ON_USAGE: Table 'AAAAAA' is marked as crashed and should be repaired
+    # this can happen with the alter table algorithm: try the safest(and slowest) COPY
+    # command: ["mysqld", "--alter-algorithm=copy"]
+  #/db

--- a/templates/_service.dockercompose.dev.yml
+++ b/templates/_service.dockercompose.dev.yml
@@ -10,10 +10,8 @@
       - type: bind
         source: ./developer/[name]
         target: /app
-      - config:/app/config
     depends_on:
       - redis
-      - config
     working_dir: /app
     command: [ "node", "--inspect=0.0.0.0:9229", "app.js" ]
   #/[name]

--- a/templates/_service.dockercompose.override.dev.yml
+++ b/templates/_service.dockercompose.override.dev.yml
@@ -4,4 +4,6 @@
   # [name]:
   #   ports:
   #     - "9229:9229"
+  #   # extends:
+  #   #   service: common_config
   #/[name]

--- a/templates/_service.dockercompose.yml
+++ b/templates/_service.dockercompose.yml
@@ -5,10 +5,8 @@
   #   image: digiserve/ab-[containerName]:<%=tag%>
   #   environment:
   #    - COTE_DISCOVERY_REDIS_HOST=redis
+  #    - MYSQL_PASSWORD
   #   hostname: [name]
-  #   volumes:
-  #     - config:/app/config
   #   depends_on:
   #     - redis
-  #     - config
   # #/[name]

--- a/templates/setup/.env
+++ b/templates/setup/.env
@@ -75,6 +75,8 @@ AB_USER_MANAGER_VERSION=<%= tag %>
 ##
 CYPRESS_BASE_URL=<%= cypressBaseURL %>
 CYPRESS_STACK=<%= cypressStack %>
+CYPRESS_DB_USER=root
+CYPRESS_DB_PASSWORD=root
 
 ##
 ## Api_Sails

--- a/templates/setup/.env
+++ b/templates/setup/.env
@@ -1,0 +1,163 @@
+# Docker/Podman stack name
+STACKNAME=<%= stack %>
+
+# Credentials
+MYSQL_PASSWORD=<%= dbPassword %>
+
+# External port numbers
+WEB_PORT=<%= port %>
+DB_PORT=<%= dbPort %>
+
+##
+## Authentication
+## the default authentication is a login/password auth.
+## If you want to use CAS or OKTA, configure that here:
+
+# CAS authentication
+CAS_ENABLED=<%= casEnabled %>
+CAS_BASE_URL=<%= casBaseURL %>
+CAS_UUID_KEY=<%= casUUIDKey %>
+
+# OKTA authentication
+OKTA_ENABLED=<%= oktaEnabled %>
+OKTA_DOMAIN=<%= oktaDomain %>
+OKTA_CLIENT_ID=<%= oktaClientID %>
+OKTA_CLIENT_SECRET=<%= oktaClientSecret %>
+
+# External URL to the site
+# So CAS & Okta know where to redirect back to.
+SITE_URL=<%= siteURL %>
+
+# Relay / Mobile App
+RELAY_ENABLE=<%= relayEnabled %>
+RELAY_SERVER_URL=<%= relayServerURL %>
+RELAY_SERVER_TOKEN=<%= relayServerToken %>
+PWA_URL=<%= pwaURL %>
+
+# SSL file paths
+# SSL_PATH_TO_PEM=
+# SSL_PATH_TO_KEY=
+
+# Docker image versions
+AB_WEB_VERSION=<%= tag %>
+AB_DB_VERSION=<%= tag %>
+AB_API_SAILS_VERSION=<%= tag %>
+AB_APPBUILDER_VERSION=<%= tag %>
+AB_BOT_MANAGER_VERSION=<%= tag %>
+AB_CUSTOM_REPORTS_VERSION=<%= tag %>
+AB_DEFINITION_MANAGER_VERSION=<%= tag %>
+AB_FILE_PROCESSOR_VERSION=<%= tag %>
+AB_LOG_MANAGER_VERSION=<%= tag %>
+AB_NOTIFICATION_EMAIL_VERSION=<%= tag %>
+AB_PROCESS_MANAGER_VERSION=<%= tag %>
+AB_RELAY_VERSION=<%= tag %>
+AB_TENANT_MANAGER_VERSION=<%= tag %>
+AB_USER_MANAGER_VERSION=<%= tag %>
+
+
+#
+# Other Possible settings for our services:
+#
+
+## MYSQL Settings:
+## These are the optional MYSQL connection settings along with their
+## default values.
+# MYSQL_HOST="db"
+# MYSQL_PORT=3306
+# MYSQL_USER=root
+# MYSQL_DBPREFIX="appbuilder"
+# MYSQL_DBADMIN="appbuilder-admin"
+# MYSQL_POOL_MAX=30
+# MYSQL_POOL_ACQUIRE_TIMEOUT=90000
+
+##
+## Cypress Settings
+##
+CYPRESS_BASE_URL=<%= cypressBaseURL %>
+CYPRESS_STACK=<%= cypressStack %>
+
+##
+## Api_Sails
+##
+SAILS_SESSION_SECRET="<%= sailsSessionSecret %>"
+## NOTE: this value should be unique for each site. If you change it on a
+##       running site, it will cause all users to re authenticate.
+
+# Appbuilder service
+# APPBUILDER_ENABLE=[true,false]
+# CIRCUITBREAKER_TIMEOUT=3000
+# CIRCUITBREAKER_THRESHHOLD=50
+# CIRCUITBREAKER_RESET=30000
+
+
+# Bot Manager
+# BOT_DOCKERHUB_ENABLE=[true,false]
+# BOT_DOCKERHUB_PORT=14000
+# BOT_SLACKBOT_ENABLE=[true,false]
+# BOT_SLACKBOT_TOKEN="xoxb-......"
+# BOT_SLACKBOT_NAME="SkyNet"
+# BOT_SLACKBOT_CHANNEL="DevOps"
+# BOT_SLACKBOT_PORT=14001
+# BOT_SLACKBOT_SIGNINGSECRET="Open Slack App; Basic Information > App Credentials > Signing Secret"
+# BOT_SLACKBOT_SOCKETMODE=[true,false]
+# BOT_SLACKBOT_APPTOKEN="xapp-....."
+# BOT_TRIGGERS="JSON.stringify({your data structure})"
+# BOT_COMMANDS="JSON.stringify({your data structure})"
+# BOT_HOST_SOCK_PATH="/tmp/appbuilder.sock"
+# BOT_HOST_TCP_PORT="1338"
+# BOT_HOST_TCP_ACCESSTOKEN="....."
+
+
+# Custom Reports
+# CUSTOM_REPORTS_ENABLE=[true,false]
+
+
+# Definition Manager
+# DEFINITION_MANAGER_ENABLE=[true,false]
+
+
+# File Processor
+# FILE_PROCESSOR_ENABLE=[true,false]
+# FILE_PROCESSOR_PATH="/data"
+# FILE_PROCESSOR_UPLOAD_DIR="tmp"
+# FILE_PROCESSOR_MAXBYTES=10000000
+# CLAMAV_ENABLED=true
+
+
+# Log Manager
+# LOG_MANAGER_ENABLE=[true,false]
+# SENTRY_ENABLED=[true,false]
+# SENTRY_DSN="url to send the events to"
+# SENTRY_SAMPLE_RATE=[0.0 - 1.0] # percent of error events that get sent: 1.0 == 100%
+# SENTRY_SERVER_NAME="<%= stack %>_Appbuilder"
+## or if you need more complicated settings:
+## SENTRY_CONFIG="JSON.stringify({your.sentry.config})"
+
+
+# Notification Email
+# NOTIFICATION_EMAIL_ENABLE=[true,false]
+# NOTIFICATION_EMAIL_DEFAULT=[smtp, mailchimp, etc...]
+# SMTP_HOST="smtp.host.com"
+# SMTP_PORT=465  # or 25
+# SMTP_SECURE=[true,false]  #use ssl encryption
+# SMTP_USER="user.name@email.com"
+# SMTP_PASSWORD="<ThereIsNoSpoon>"
+## NOTE: if you want to use a more complicated setup, you can provide
+## SMTP_AUTH which specifies more authentication options according to:
+## https://nodemailer.com/smtp/#authentication
+## SMTP_AUTH="JSON.stringify({your.auth.data})"
+
+
+# Process Manager
+# PROCESS_MANAGER_ENABLE=[true,false]
+
+
+# Tenant Manager
+# TENANT_MANAGER_ENABLE=[true,false]
+## Only change the TENANT_MANAGER_TENANT_ID if you know what your doing.
+## TENANT_MANAGER_TENANT_ID="TenantSite.uuid"
+
+
+# User Manager
+# USER_MANAGER_ENABLE=[true,false]
+# USER_MANAGER_MAX_FAILED_LOGINS=5

--- a/templates/setup/[stack]_system_monitor.js
+++ b/templates/setup/[stack]_system_monitor.js
@@ -238,7 +238,7 @@ var serviceNames = {};
 // a quick lookup hash with the names of the current docker stack + service
 // name for each of our servicesToWatch.
 
-var stack = "<%= stack %>";
+var stack = process.env.STACKNAME || "<%= stack %>";
 // {string}
 // the docker stack reference for this running stack.
 

--- a/templates/setup/[stack]_system_monitor.js
+++ b/templates/setup/[stack]_system_monitor.js
@@ -97,40 +97,41 @@ var parseLine = /(\w+)\s+(\w+)\s+\w+\s+0\/\d+\s+([\w\/:-]+)/g; // eslint-disable
 function checkRunning() {
    // make sure our connection to our botManager is ok before trying:
    if (currStream && !currStream.destroyed) {
-      shell.exec("docker service ls", { silent: true }, (
-         code,
-         stdout /* , stderr */
-      ) => {
-         if (code == 0) {
-            if (stdout.search(downCheck) == -1) {
-               if (isReportRunning) {
-                  console.log("... looks like server is running.");
-                  if (currStream) {
-                     currStream.write("__running");
-                  }
+      shell.exec(
+         "docker service ls",
+         { silent: true },
+         (code, stdout /* , stderr */) => {
+            if (code == 0) {
+               if (stdout.search(downCheck) == -1) {
+                  if (isReportRunning) {
+                     console.log("... looks like server is running.");
+                     if (currStream) {
+                        currStream.write("__running");
+                     }
 
-                  isReportRunning = false;
-               }
-            } else {
-               var lines = stdout.split("\n");
-               var offlineContainers = [];
-               lines.forEach((l) => {
-                  var match = parseLine.exec(l);
-                  if (match) {
-                     offlineContainers.push(`${match[2]}`); // ${match[2]}(${match[3]})
+                     isReportRunning = false;
                   }
-               });
-               if (offlineContainers.length > 0) {
-                  if (currStream) {
-                     currStream.write(
-                        "__offline:" + offlineContainers.join(",")
-                     );
+               } else {
+                  var lines = stdout.split("\n");
+                  var offlineContainers = [];
+                  lines.forEach((l) => {
+                     var match = parseLine.exec(l);
+                     if (match) {
+                        offlineContainers.push(`${match[2]}`); // ${match[2]}(${match[3]})
+                     }
+                  });
+                  if (offlineContainers.length > 0) {
+                     if (currStream) {
+                        currStream.write(
+                           "__offline:" + offlineContainers.join(",")
+                        );
+                     }
+                     isReportRunning = true;
                   }
-                  isReportRunning = true;
                }
             }
          }
-      });
+      );
    } else {
       console.log("connection to botManager is not active.");
    }
@@ -237,7 +238,7 @@ var serviceNames = {};
 // a quick lookup hash with the names of the current docker stack + service
 // name for each of our servicesToWatch.
 
-var stack = "ab";
+var stack = "<%= stack %>";
 // {string}
 // the docker stack reference for this running stack.
 

--- a/templates/setup/config/local.js
+++ b/templates/setup/config/local.js
@@ -39,7 +39,7 @@ module.exports = {
 
    /** Session */
    session: {
-      secret: "<%=sailsSessionSecret%>",
+      secret: process.env.SAILS_SESSION_SECRET || "<%=sailsSessionSecret%>",
       // Session secret is automatically generated during install.
       // Replace at your own risk in production-- you will invalidate the cookies
       // of your users, forcing them to log in again.     

--- a/templates/setup/config/local.js
+++ b/templates/setup/config/local.js
@@ -39,11 +39,12 @@ module.exports = {
 
    /** Session */
    session: {
-      secret: "<%=secret%>",
+      secret: "<%=sailsSessionSecret%>",
       // Session secret is automatically generated during install.
       // Replace at your own risk in production-- you will invalidate the cookies
       // of your users, forcing them to log in again.     
    },
+
    <% if (!develop) { %>
    sockets: {
       /**
@@ -60,7 +61,8 @@ module.exports = {
          return proceed(undefined, true);
       },
    },
-   <% } %>  
+   <% } %>
+
    /**
     * CAS authentication
     */

--- a/templates/setup/docker-compose.dev.yml
+++ b/templates/setup/docker-compose.dev.yml
@@ -1,0 +1,435 @@
+version: "3.9"
+
+volumes:
+  files:
+  mysql_data:
+  redis_data:
+  # clamav:
+
+networks:
+  default:
+    attachable: true
+
+services:
+  #nginx setup
+  web:
+    image: docker.io/digiserve/ab-web:$AB_WEB_VERSION
+    hostname: web
+    volumes:
+      - type: bind
+        source: ./nginx/html
+        target: /usr/share/nginx/html
+      - files:/data
+      - type: bind
+        source: ./developer/web/assets
+        target: /app/assets
+    depends_on:
+      - api_sails
+   #/nginx
+
+  #db: use Maria DB as our backend DB
+  db:
+    image: docker.io/digiserve/ab-db:$AB_DB_VERSION
+    environment:
+      MYSQL_ROOT_PASSWORD: $MYSQL_PASSWORD # from .env
+    volumes:
+      - mysql_data:/var/lib/mysql
+    # on windows: use this command. (be sure to clear out mysql/data folder)
+    # command: mysqld --innodb-flush-method=littlesync --innodb-use-native-aio=OFF --log_bin=ON --wait-timeout=60 --interactive-timeout=60
+    ######
+    # when there is a problem with : Error: ER_CRASHED_ON_USAGE: Table 'AAAAAA' is marked as crashed and should be repaired
+    # this can happen with the alter table algorithm: try the safest(and slowest) COPY
+    command: ["mysqld", "--alter-algorithm=copy" , "--wait-timeout=60", "--interactive-timeout=60"]
+  #/db
+
+
+  #redis: use redis to allow cote services to find each other across a swarm
+  redis:
+    image: redis
+    hostname: redis
+    volumes:
+      - redis_data:/data
+    command: redis-server --appendonly yes
+  #/redis
+
+
+  #api_sails: our API end point
+  api_sails:
+    image: node
+    environment:
+      - COTE_DISCOVERY_REDIS_HOST=redis
+      - NODE_ENV=development
+      - MYSQL_PASSWORD
+      # - MYSQL_HOST
+      # - MYSQL_PORT
+      # - MYSQL_USER
+      # - MYSQL_DBPREFIX
+      # - MYSQL_DBADMIN
+      # - MYSQL_POOL_MAX
+      # - MYSQL_POOL_ACQUIRE_TIMEOUT
+      - CAS_ENABLED
+      - CAS_BASE_URL
+      - CAS_UUID_KEY
+      - SITE_URL
+      - OKTA_ENABLED
+      - OKTA_DOMAIN
+      - OKTA_CLIENT_ID
+      - OKTA_CLIENT_SECRET
+      # - FILE_PROCESSOR_PATH
+      # - FILE_PROCESSOR_UPLOAD_DIR
+      # - FILE_PROCESSOR_MAXBYTES
+      - RELAY_ENABLED
+      - RELAY_SERVER_TOKEN
+      - SAILS_SESSION_SECRET
+    volumes:
+      - type: bind
+        source: ./developer/api_sails
+        target: /app
+      - type: bind
+        source: ./logs/appbuilder/
+        target: /var/log/appbuilder/
+      - files:/data
+    depends_on:
+      - redis
+    working_dir: /app
+    command: [ "node", "--inspect=0.0.0.0:9229", "app_waitMysql.js" ]
+  #/api_sails
+
+
+  #appbuilder: (AppBuilder) A multi-tenant aware service to process our AppBuilder requests.
+  appbuilder:
+    image: node
+    environment:
+      - COTE_DISCOVERY_REDIS_HOST=redis
+      - MYSQL_PASSWORD
+      # - MYSQL_HOST
+      # - MYSQL_PORT
+      # - MYSQL_USER
+      # - MYSQL_DBPREFIX
+      # - MYSQL_DBADMIN
+      # - MYSQL_POOL_MAX
+      # - MYSQL_POOL_ACQUIRE_TIMEOUT
+      - APPBUILDER_ENABLE
+      - CIRCUITBREAKER_TIMEOUT
+      - CIRCUITBREAKER_THRESHHOLD
+      - CIRCUITBREAKER_RESET
+    hostname: appbuilder
+    volumes:
+      - type: bind
+        source: ./developer/appbuilder
+        target: /app
+    depends_on:
+      - redis
+    working_dir: /app
+    # command: npm run dev  # <-- runs nodemon and auto starts when code changes
+    command: [ "node", "--inspect=0.0.0.0:9229", "app.js" ]
+  #/appbuilder
+
+
+  #bot_manager: our #slack bot service
+  bot_manager:
+    image: node
+    environment:
+      - COTE_DISCOVERY_REDIS_HOST=redis
+      # - BOT_DOCKERHUB_ENABLE
+      # - BOT_DOCKERHUB_PORT
+      # - BOT_SLACKBOT_ENABLE
+      # - BOT_SLACKBOT_TOKEN
+      # - BOT_SLACKBOT_NAME
+      # - BOT_SLACKBOT_CHANNEL
+      # - BOT_SLACKBOT_PORT
+      # - BOT_SLACKBOT_SIGNINGSECRET
+      # - BOT_SLACKBOT_SOCKETMODE
+      # - BOT_SLACKBOT_APPTOKEN
+      # - BOT_TRIGGERS
+      # - BOT_COMMANDS
+      # - BOT_HOST_SOCK_PATH
+      # - BOT_HOST_TCP_PORT
+      # - BOT_HOST_TCP_ACCESSTOKEN
+    volumes:
+      - type: bind
+        source: ./developer/bot_manager
+        target: /app
+      # sharing .sock files currently don't work on docker-for-mac:
+      # https://github.com/docker/for-mac/issues/483
+      # For a Mac host, configure config/local.js to hostConnection.tcp
+      # but it doesn't hurt to include the /tmp dir for all platforms.
+      - type: bind
+        source: /tmp
+        target: /tmp
+    depends_on:
+      - redis
+    working_dir: /app
+    command: [ "node", "--inspect=0.0.0.0:9229", "app.js" ]
+  #/bot_manager
+
+
+  #custom_reports: A service for custom reports.
+  custom_reports:
+    image: node
+    environment:
+      - COTE_DISCOVERY_REDIS_HOST=redis
+      - MYSQL_PASSWORD
+      # - MYSQL_HOST
+      # - MYSQL_PORT
+      # - MYSQL_USER
+      # - MYSQL_DBPREFIX
+      # - MYSQL_DBADMIN
+      # - MYSQL_POOL_MAX
+      # - MYSQL_POOL_ACQUIRE_TIMEOUT
+      - CUSTOM_REPORTS_ENABLED
+    hostname: custom_reports
+    volumes:
+      - type: bind
+        source: ./developer/custom_reports
+        target: /app
+    depends_on:
+      - redis
+    working_dir: /app
+    command: [ "node", "--inspect=0.0.0.0:9229", "app.js" ]
+  #/custom_reports
+
+
+  #definition_manager: (AppBuilder) A service to manage the definitions for a running AppBuilder platform.
+  definition_manager:
+    image: node
+    environment:
+      - COTE_DISCOVERY_REDIS_HOST=redis
+      - MYSQL_PASSWORD
+      # - MYSQL_HOST
+      # - MYSQL_PORT
+      # - MYSQL_USER
+      # - MYSQL_DBPREFIX
+      # - MYSQL_DBADMIN
+      # - MYSQL_POOL_MAX
+      # - MYSQL_POOL_ACQUIRE_TIMEOUT
+      - DEFINITION_MANAGER_ENABLE
+    hostname: definition_manager
+    volumes:
+      - type: bind
+        source: ./developer/definition_manager
+        target: /app
+    depends_on:
+      - redis
+    working_dir: /app
+    command: [ "node", "--inspect=0.0.0.0:9229", "app.js" ]
+  #/definition_manager
+
+
+  #file_processor: A service to manage uploaded files.
+  file_processor:
+    image: node
+    environment:
+      - COTE_DISCOVERY_REDIS_HOST=redis
+      - MYSQL_PASSWORD
+      # - MYSQL_HOST
+      # - MYSQL_PORT
+      # - MYSQL_USER
+      # - MYSQL_DBPREFIX
+      # - MYSQL_DBADMIN
+      # - MYSQL_POOL_MAX
+      # - MYSQL_POOL_ACQUIRE_TIMEOUT
+      - FILE_PROCESSOR_ENABLE
+      # - FILE_PROCESSOR_PATH
+      # - FILE_PROCESSOR_UPLOAD_DIR
+      # - FILE_PROCESSOR_MAXBYTES
+      # - CLAMAV_ENABLED
+    hostname: file_processor
+    volumes:
+      - type: bind
+        source: ./developer/file_processor
+        target: /app
+      - files:/data
+    depends_on:
+      - redis
+    working_dir: /app
+    command: [ "node", "--inspect=0.0.0.0:9229", "app.js" ]
+  #/file_processor
+
+
+  #log_manager: (AppBuilder) A log manager for various AB operations
+  log_manager:
+    image: node
+    environment:
+      - COTE_DISCOVERY_REDIS_HOST=redis
+      - MYSQL_PASSWORD
+      # - MYSQL_HOST
+      # - MYSQL_PORT
+      # - MYSQL_USER
+      # - MYSQL_DBPREFIX
+      # - MYSQL_DBADMIN
+      # - MYSQL_POOL_MAX
+      # - MYSQL_POOL_ACQUIRE_TIMEOUT
+      - SENTRY_ENABLED
+      - SENTRY_DSN
+      - SENTRY_SAMPLE_RATE
+      - SENTRY_SERVER_NAME
+      # - SENTRY_CONFIG
+    hostname: log_manager
+    volumes:
+      - type: bind
+        source: ./developer/log_manager
+        target: /app
+    depends_on:
+      - redis
+    working_dir: /app
+    command: [ "node", "--inspect=0.0.0.0:9229", "app.js" ]
+  #/log_manager
+
+
+  #notification_email: an smtp email service
+  notification_email:
+    image: node
+    environment:
+      - COTE_DISCOVERY_REDIS_HOST=redis
+      - MYSQL_PASSWORD
+      # - MYSQL_HOST
+      # - MYSQL_PORT
+      # - MYSQL_USER
+      # - MYSQL_DBPREFIX
+      # - MYSQL_DBADMIN
+      # - MYSQL_POOL_MAX
+      # - MYSQL_POOL_ACQUIRE_TIMEOUT
+      - NOTIFICATION_EMAIL_ENABLE
+      - NOTIFICATION_EMAIL_DEFAULT
+      - SMTP_HOST
+      - SMTP_PORT
+      - SMTP_SECURE
+      # Default Auth Method is "login"
+      # specify the user/password
+      - SMTP_USER
+      - SMTP_PASSWORD
+      # For more complicated methods:
+      # - SMTP_AUTH="{ login config }"
+    hostname: notification_email
+    volumes:
+      - type: bind
+        source: ./developer/notification_email
+        target: /app
+    depends_on:
+      - redis
+    working_dir: /app
+    command: [ "node", "--inspect=0.0.0.0:9229", "app.js" ]
+  #/notification_email
+
+
+  #process_manager: (AppBuilder) a micro service to manage our process tasks
+  process_manager:
+    image: node
+    environment:
+      - COTE_DISCOVERY_REDIS_HOST=redis
+      - MYSQL_PASSWORD
+      # - MYSQL_HOST
+      # - MYSQL_PORT
+      # - MYSQL_USER
+      # - MYSQL_DBPREFIX
+      # - MYSQL_DBADMIN
+      # - MYSQL_POOL_MAX
+      # - MYSQL_POOL_ACQUIRE_TIMEOUT
+    hostname: process_manager
+    volumes:
+      - type: bind
+        source: ./developer/process_manager
+        target: /app
+    depends_on:
+      - redis
+    working_dir: /app
+    command: [ "node", "--inspect=0.0.0.0:9229", "app.js" ]
+  #/process_manager
+
+
+  #relay: (Appbuilder} A service to handle the communications with our relay server.
+  relay:
+    image: node
+    environment:
+      - COTE_DISCOVERY_REDIS_HOST=redis
+      - MYSQL_PASSWORD
+      # - MYSQL_HOST
+      # - MYSQL_PORT
+      # - MYSQL_USER
+      # - MYSQL_DBPREFIX
+      # - MYSQL_DBADMIN
+      # - MYSQL_POOL_MAX
+      # - MYSQL_POOL_ACQUIRE_TIMEOUT
+      - RELAY_ENABLE
+      - RELAY_SERVER_URL
+      - RELAY_SERVER_TOKEN
+      - RELAY_POLL_FREQUENCY
+      - RELAY_MAX_PACKET_SIZE
+      - PWA_URL
+    hostname: relay
+    volumes:
+      - type: bind
+        source: ./developer/relay
+        target: /app
+    depends_on:
+      - redis
+    working_dir: /app
+    command: [ "node", "--inspect=0.0.0.0:9229", "app.js" ]
+  #/relay
+
+
+  #tenant_manager: (AppBuilder) A service to manage the site's tenants
+  tenant_manager:
+    image: node
+    environment:
+      - COTE_DISCOVERY_REDIS_HOST=redis
+      - MYSQL_PASSWORD
+      # - MYSQL_HOST
+      # - MYSQL_PORT
+      # - MYSQL_USER
+      # - MYSQL_DBPREFIX
+      # - MYSQL_DBADMIN
+      # - MYSQL_POOL_MAX
+      # - MYSQL_POOL_ACQUIRE_TIMEOUT
+      - TENANT_MANAGER_ENABLE
+      # - TENANT_MANAGER_TENANT_ID
+    hostname: tenant_manager
+    volumes:
+      - type: bind
+        source: ./developer/tenant_manager
+        target: /app
+    depends_on:
+      - redis
+    working_dir: /app
+    command: [ "node", "--inspect=0.0.0.0:9229", "app.js" ]
+  #/tenant_manager
+
+
+  #user_manager: (AppBuilder) A microservice for managing Users
+  user_manager:
+    image: node
+    environment:
+      - COTE_DISCOVERY_REDIS_HOST=redis
+      - MYSQL_PASSWORD
+      # - MYSQL_HOST
+      # - MYSQL_PORT
+      # - MYSQL_USER
+      # - MYSQL_DBPREFIX
+      # - MYSQL_DBADMIN
+      # - MYSQL_POOL_MAX
+      # - MYSQL_POOL_ACQUIRE_TIMEOUT
+      - USER_MANAGER_ENABLE
+      - USER_MANAGER_MAX_FAILED_LOGINS
+    hostname: user_manager
+    volumes:
+      - type: bind
+        source: ./developer/user_manager
+        target: /app
+    depends_on:
+      - redis
+    working_dir: /app
+    command: [ "node", "--inspect=0.0.0.0:9229", "app.js" ]
+  #/user_manager
+
+
+#  #watchtower: monitor and update our running containers
+#  watchtower:
+#    image: v2tec/watchtower
+#    volumes:
+#      # - /var/run/docker.sock:/var/run/docker.sock
+#      - type: bind
+#        source: /var/run/docker.sock
+#        target: /var/run/docker.sock
+#    command: --interval 10 --debug
+#  #/watchtower

--- a/templates/setup/docker-compose.override.yml
+++ b/templates/setup/docker-compose.override.yml
@@ -23,7 +23,7 @@ services:
   #nginx setup
   web:
     ports:
-      - "<%=port%>:80"
+      - "${WEB_PORT}:80"
       - "443:443"
     # extends:
     #   service: common_config
@@ -32,7 +32,7 @@ services:
   #db: use Maria DB as our backend DB
   <%= dbExpose ? "" : "# " %>db:
   <%= dbExpose ? "" : "# " %>  ports:
-  <%= dbExpose ? "" : "# " %>    - "<%=dbPort%>:3306"
+  <%= dbExpose ? "" : "# " %>    - "${DB_PORT}:3306"
   <%= dbExpose ? "" : "# " %>  # extends:
   <%= dbExpose ? "" : "# " %>  #   service: common_config
 

--- a/templates/setup/docker-compose.override.yml
+++ b/templates/setup/docker-compose.override.yml
@@ -1,0 +1,143 @@
+version: "3.9"
+
+services:
+
+  # # common settings for all our services:
+  # common_config:
+  #   deploy:
+  #     replicas: 1
+  #     update_config:
+  #       parallelism: 1
+  #       order: start-first
+  #       failure_action: rollback
+  #       delay: 10s
+  #     rollback_config:
+  #       parallelism: 0
+  #       order: stop-first
+  #     restart_policy:
+  #       condition: any
+  #       delay: 5s
+  #       max_attempts: 3
+  #       window: 120s
+
+  #nginx setup
+  web:
+    ports:
+      - "<%=port%>:80"
+      - "443:443"
+    # extends:
+    #   service: common_config
+
+
+  #db: use Maria DB as our backend DB
+  <%= dbExpose ? "" : "# " %>db:
+  <%= dbExpose ? "" : "# " %>  ports:
+  <%= dbExpose ? "" : "# " %>    - "<%=dbPort%>:3306"
+  <%= dbExpose ? "" : "# " %>  # extends:
+  <%= dbExpose ? "" : "# " %>  #   service: common_config
+
+
+  # #redis: use redis to allow cote services to find each other across a swarm
+  # redis:
+  #   ports:
+  #    - 6379:6379
+  #   # extends:
+  #   #   service: common_config
+
+
+  # #api_sails: our API end point
+  # api_sails:
+  #   ports:
+  #     - "1337:1337"
+  #     - "9229:9229"
+  #   # extends:
+  #   #   service: common_config
+
+
+  # #appbuilder: (AppBuilder) A multi-tenant aware service to process our AppBuilder requests.
+  # appbuilder:
+  #   ports:
+  #     - "9229:9229"
+  #   # extends:
+  #   #   service: common_config
+
+
+  # #bot_manager: our #slack bot service
+  # bot_manager:
+  #   ports:
+  #     - "3000:3000"
+  #     - "9229:9229"
+  #   # extends:
+  #   #   service: common_config
+
+
+  # #custom_reports: (AppBuilder) A microservice for Custom Reports
+  # custom_reports:
+  #   ports:
+  #     - "9229:9229"
+  #   # extends:
+  #   #   service: common_config
+
+
+  # #definition_manager: (AppBuilder) A service to manage the definitions for a running AppBuilder platform.
+  # definition_manager:
+  #   ports:
+  #     - "9229:9229"
+  #   # extends:
+  #   #   service: common_config
+
+
+  # #file_processor: A service to manage uploaded files.
+  # file_processor:
+  #   ports:
+  #     - "9229:9229"
+  #   # extends:
+  #   #   service: common_config
+
+
+  # #log_manager: (AppBuilder) A log manager for various AB operations
+  # log_manager:
+  #   ports:
+  #     - "9229:9229"
+  #   # extends:
+  #   #   service: common_config
+
+
+  # #notification_email: an smtp email service
+  # notification_email:
+  #   ports:
+  #     - "9229:9229"
+  #   # extends:
+  #   #   service: common_config
+
+
+  # #process_manager: (AppBuilder) a micro service to manage our process tasks
+  # process_manager:
+  #   ports:
+  #     - "9229:9229"
+  #   # extends:
+  #   #   service: common_config
+
+
+  # #relay: (AppBuilder) a service to manage our communications with our relay server
+  # relay:
+  #   ports:
+  #     - "9229:9229"
+  #   # extends:
+  #   #   service: common_config
+
+
+  # #tenant_manager: (AppBuilder) A service to manage the site's tenants
+  # tenant_manager:
+  #   ports:
+  #     - "9229:9229"
+  #   # extends:
+  #   #   service: common_config
+
+
+  # #user_manager: (AppBuilder) A microservice for managing Users
+  # user_manager:
+  #   ports:
+  #     - "9229:9229"
+  #   # extends:
+  #   #   service: common_config

--- a/templates/setup/docker-compose.yml
+++ b/templates/setup/docker-compose.yml
@@ -1,0 +1,393 @@
+version: "3.9"
+
+volumes:
+  files:
+  mysql_data:
+  redis_data:
+  # clamav:
+
+networks:
+  default:
+    attachable: true
+
+services:
+
+  #nginx setup
+  web:
+    image: docker.io/digiserve/ab-web:$AB_WEB_VERSION
+    hostname: web
+    volumes:
+      - files:/data
+    depends_on:
+      - api_sails
+  #/nginx
+
+
+  #db: use Maria DB as our backend DB
+  db:
+    image: docker.io/digiserve/ab-db:$AB_DB_VERSION
+    environment:
+      MYSQL_ROOT_PASSWORD: $MYSQL_PASSWORD
+    volumes:
+      # - mysql_config:/etc/mysql/conf.d
+      - mysql_data:/var/lib/mysql
+      # - mysql_key:/key
+    # on windows: use this command. (be sure to clear out mysql/data folder)
+    # command: mysqld --innodb-flush-method=littlesync --innodb-use-native-aio=OFF --log_bin=ON
+    ######
+    # when there is a problem with : Error: ER_CRASHED_ON_USAGE: Table 'AAAAAA' is marked as crashed and should be repaired
+    # this can happen with the alter table algorithm: try the safest(and slowest) COPY
+    # command: ["mysqld", "--alter-algorithm=copy"]
+  #/db
+
+
+  #redis: use redis to allow cote services to find each other across a swarm
+  redis:
+    image: docker.io/redis
+    ## NOTE: don't expose the service to the outside for security:
+    ## if you do expose it, then set a password.
+    hostname: redis
+    volumes:
+      - redis_data:/data
+    command: redis-server --appendonly yes
+  #/redis
+
+
+  # #config: simply exists to pull in the config/local.js into our config volume
+  # config:
+  #   image: docker.io/digiserve/ab-config:$AB_CONFIG_VERSION
+  #   # workaround for SELinux bind mount issue (for podman only)
+  #   # security_opt:
+  #   #   label: disable
+  #   hostname: config
+  #   volumes:
+  #     - type: bind
+  #       source: ./config/local.js
+  #       target: /config_safe/local.js
+  #     - config:/config
+  #   working_dir: /app
+  #   command: ["node", "app.js"]
+  # #/config
+
+
+  #api_sails: our API end point
+  api_sails:
+    image: docker.io/digiserve/ab-api-sails:$AB_API_SAILS_VERSION
+    # workaround for SELinux bind mount issue (for podman only)
+    # security_opt:
+    #   label: disable
+    environment:
+      - COTE_DISCOVERY_REDIS_HOST=redis
+      - NODE_ENV=development
+      - MYSQL_PASSWORD
+      # - MYSQL_HOST
+      # - MYSQL_PORT
+      # - MYSQL_USER
+      # - MYSQL_DBPREFIX
+      # - MYSQL_DBADMIN
+      # - MYSQL_POOL_MAX
+      # - MYSQL_POOL_ACQUIRE_TIMEOUT
+      - CAS_ENABLED
+      - CAS_BASE_URL
+      - CAS_UUID_KEY
+      - SITE_URL
+      - OKTA_ENABLED
+      - OKTA_DOMAIN
+      - OKTA_CLIENT_ID
+      - OKTA_CLIENT_SECRET
+      # - FILE_PROCESSOR_PATH
+      # - FILE_PROCESSOR_UPLOAD_DIR
+      # - FILE_PROCESSOR_MAXBYTES
+      - RELAY_ENABLED
+      - RELAY_SERVER_TOKEN
+      - SAILS_SESSION_SECRET
+    hostname: api_sails
+    volumes:
+      - type: bind
+        source: ./logs/appbuilder/
+        target: /var/log/appbuilder/
+      - files:/data
+    depends_on:
+      - redis
+    # command: [ "node", "--inspect=0.0.0.0:9229", "app.js" ]
+  #/api_sails
+
+
+  #appbuilder: (AppBuilder) A multi-tenant aware service to process our AppBuilder requests.
+  appbuilder:
+    image: docker.io/digiserve/ab-appbuilder:$AB_APPBUILDER_VERSION
+    environment:
+      - COTE_DISCOVERY_REDIS_HOST=redis
+      - MYSQL_PASSWORD
+      # - MYSQL_HOST
+      # - MYSQL_PORT
+      # - MYSQL_USER
+      # - MYSQL_DBPREFIX
+      # - MYSQL_DBADMIN
+      # - MYSQL_POOL_MAX
+      # - MYSQL_POOL_ACQUIRE_TIMEOUT
+      - APPBUILDER_ENABLE
+      - CIRCUITBREAKER_TIMEOUT
+      - CIRCUITBREAKER_THRESHHOLD
+      - CIRCUITBREAKER_RESET
+    hostname: appbuilder
+    depends_on:
+      - redis
+    # command: [ "node", "--inspect=0.0.0.0:9229", "app.js" ]
+  #/appbuilder
+
+
+  # #bot_manager: our #slack bot service
+  # bot_manager:
+  #   image: digiserve/ab-bot-manager:$AB_BOT_MANAGER_VERSION
+  #   environment:
+  #     - COTE_DISCOVERY_REDIS_HOST=redis
+  #     - BOT_DOCKERHUB_ENABLE
+  #     - BOT_DOCKERHUB_PORT
+  #     - BOT_SLACKBOT_ENABLE
+  #     - BOT_SLACKBOT_TOKEN
+  #     - BOT_SLACKBOT_NAME
+  #     - BOT_SLACKBOT_CHANNEL
+  #     - BOT_SLACKBOT_PORT
+  #     - BOT_SLACKBOT_SIGNINGSECRET
+  #     - BOT_SLACKBOT_SOCKETMODE
+  #     - BOT_SLACKBOT_APPTOKEN
+  #     - BOT_TRIGGERS
+  #     - BOT_COMMANDS
+  #     - BOT_HOST_SOCK_PATH
+  #     - BOT_HOST_TCP_PORT
+  #     - BOT_HOST_TCP_ACCESSTOKEN
+  #   hostname: bot_manager
+  #   # volumes:
+  #   #   # sharing .sock files currently don't work on docker-for-mac:
+  #   #   # https://github.com/docker/for-mac/issues/483
+  #   #   # For a Mac host, configure BOT_HOST_TCP_PORT & BOT_HOST_TCP_ACCESSTOKEN
+  #   #   #
+  #   #   # For other platforms, configure BOT_HOST_SOCK_PATH and share the path
+  #   #   # to your sock file:
+  #   #   - type: bind
+  #   #     source: /tmp
+  #   #     target: /tmp
+  #   depends_on:
+  #     - redis
+  # #/bot_manager
+
+
+  # custom_reports: A microservice for managing custom reports
+  custom_reports:
+    image: docker.io/digiserve/ab-custom-reports:$AB_CUSTOM_REPORTS_VERSION
+    environment:
+      - COTE_DISCOVERY_REDIS_HOST=redis
+      - MYSQL_PASSWORD
+      # - MYSQL_HOST
+      # - MYSQL_PORT
+      # - MYSQL_USER
+      # - MYSQL_DBPREFIX
+      # - MYSQL_DBADMIN
+      # - MYSQL_POOL_MAX
+      # - MYSQL_POOL_ACQUIRE_TIMEOUT
+      - CUSTOM_REPORTS_ENABLED
+    hostname: custom_reports
+    depends_on:
+      - redis
+  #/custom_reports
+
+
+  #definition_manager: (AppBuilder) A service to manage the definitions for a running AppBuilder platform.
+  definition_manager:
+    image: docker.io/digiserve/ab-definition-manager:$AB_DEFINITION_MANAGER_VERSION
+    environment:
+      - COTE_DISCOVERY_REDIS_HOST=redis
+      - MYSQL_PASSWORD
+      # - MYSQL_HOST
+      # - MYSQL_PORT
+      # - MYSQL_USER
+      # - MYSQL_DBPREFIX
+      # - MYSQL_DBADMIN
+      # - MYSQL_POOL_MAX
+      # - MYSQL_POOL_ACQUIRE_TIMEOUT
+      - DEFINITION_MANAGER_ENABLE
+    hostname: definition_manager
+    depends_on:
+      - redis
+  #/definition_manager
+
+
+  #file_processor: A service to manage uploaded files.
+  file_processor:
+    image: docker.io/digiserve/ab-file-processor:$AB_FILE_PROCESSOR_VERSION
+    environment:
+      - COTE_DISCOVERY_REDIS_HOST=redis
+      - MYSQL_PASSWORD
+      # - MYSQL_HOST
+      # - MYSQL_PORT
+      # - MYSQL_USER
+      # - MYSQL_DBPREFIX
+      # - MYSQL_DBADMIN
+      # - MYSQL_POOL_MAX
+      # - MYSQL_POOL_ACQUIRE_TIMEOUT
+      - FILE_PROCESSOR_ENABLE
+      # - FILE_PROCESSOR_PATH
+      # - FILE_PROCESSOR_UPLOAD_DIR
+      # - FILE_PROCESSOR_MAXBYTES
+      # - CLAMAV_ENABLED
+    hostname: file_processor
+    volumes:
+      - files:/data
+      # - clamav:/var/lib/clamav
+    depends_on:
+      - redis
+  #/file_processor
+
+
+  #log_manager: (AppBuilder) A log manager for various AB operations
+  log_manager:
+    image: docker.io/digiserve/ab-log-manager:$AB_LOG_MANAGER_VERSION
+    environment:
+      - COTE_DISCOVERY_REDIS_HOST=redis
+      - MYSQL_PASSWORD
+      # - MYSQL_HOST
+      # - MYSQL_PORT
+      # - MYSQL_USER
+      # - MYSQL_DBPREFIX
+      # - MYSQL_DBADMIN
+      # - MYSQL_POOL_MAX
+      # - MYSQL_POOL_ACQUIRE_TIMEOUT
+      - SENTRY_ENABLED
+      - SENTRY_DSN
+      - SENTRY_SAMPLE_RATE
+      - SENTRY_SERVER_NAME
+      # - SENTRY_CONFIG
+    hostname: log_manager
+    depends_on:
+      - redis
+  #/log_manager
+
+
+  #notification_email: an smtp email service
+  notification_email:
+    image: docker.io/digiserve/ab-notification-email:$AB_NOTIFICATION_EMAIL_VERSION
+    environment:
+      - COTE_DISCOVERY_REDIS_HOST=redis
+      - MYSQL_PASSWORD
+      # - MYSQL_HOST
+      # - MYSQL_PORT
+      # - MYSQL_USER
+      # - MYSQL_DBPREFIX
+      # - MYSQL_DBADMIN
+      # - MYSQL_POOL_MAX
+      # - MYSQL_POOL_ACQUIRE_TIMEOUT
+      - NOTIFICATION_EMAIL_ENABLE
+      - NOTIFICATION_EMAIL_DEFAULT
+      - SMTP_HOST
+      - SMTP_PORT
+      - SMTP_SECURE
+      # Default Auth Method is "login"
+      # specify the user/password
+      - SMTP_USER
+      - SMTP_PASSWORD
+      # For more complicated methods:
+      # - SMTP_AUTH="{ login config }"
+    hostname: notification_email
+    depends_on:
+      - redis
+  #/notification_email
+
+
+  #process_manager: (AppBuilder) a micro service to manage our process tasks
+  process_manager:
+    image: docker.io/digiserve/ab-process-manager:$AB_PROCESS_MANAGER_VERSION
+    environment:
+      - COTE_DISCOVERY_REDIS_HOST=redis
+      - MYSQL_PASSWORD
+      # - MYSQL_HOST
+      # - MYSQL_PORT
+      # - MYSQL_USER
+      # - MYSQL_DBPREFIX
+      # - MYSQL_DBADMIN
+      # - MYSQL_POOL_MAX
+      # - MYSQL_POOL_ACQUIRE_TIMEOUT
+    hostname: process_manager
+    depends_on:
+      - redis
+  #/process_manager
+
+
+  #relay: (Appbuilder} A service to handle the communications with our relay server.
+  relay:
+    image: docker.io/digiserve/ab-relay:$AB_RELAY_VERSION
+    environment:
+      - COTE_DISCOVERY_REDIS_HOST=redis
+      - MYSQL_PASSWORD
+      # - MYSQL_HOST
+      # - MYSQL_PORT
+      # - MYSQL_USER
+      # - MYSQL_DBPREFIX
+      # - MYSQL_DBADMIN
+      # - MYSQL_POOL_MAX
+      # - MYSQL_POOL_ACQUIRE_TIMEOUT
+      - RELAY_ENABLE
+      - RELAY_SERVER_URL
+      - RELAY_SERVER_TOKEN
+      - RELAY_POLL_FREQUENCY
+      - RELAY_MAX_PACKET_SIZE
+      - PWA_URL
+    hostname: relay
+    depends_on:
+      - redis
+  #/relay
+
+
+  #tenant_manager: (AppBuilder) A service to manage the site's tenants
+  tenant_manager:
+    image: docker.io/digiserve/ab-tenant-manager:$AB_TENANT_MANAGER_VERSION
+    environment:
+      - COTE_DISCOVERY_REDIS_HOST=redis
+      - MYSQL_PASSWORD
+      # - MYSQL_HOST
+      # - MYSQL_PORT
+      # - MYSQL_USER
+      # - MYSQL_DBPREFIX
+      # - MYSQL_DBADMIN
+      # - MYSQL_POOL_MAX
+      # - MYSQL_POOL_ACQUIRE_TIMEOUT
+      - TENANT_MANAGER_ENABLE
+      # - TENANT_MANAGER_TENANT_ID
+    hostname: tenant_manager
+    depends_on:
+      - redis
+  #/tenant_manager
+
+
+  #user_manager: (AppBuilder) A microservice for managing Users
+  user_manager:
+    image: docker.io/digiserve/ab-user-manager:$AB_USER_MANAGER_VERSION
+    environment:
+      - COTE_DISCOVERY_REDIS_HOST=redis
+      - MYSQL_PASSWORD
+      # - MYSQL_HOST
+      # - MYSQL_PORT
+      # - MYSQL_USER
+      # - MYSQL_DBPREFIX
+      # - MYSQL_DBADMIN
+      # - MYSQL_POOL_MAX
+      # - MYSQL_POOL_ACQUIRE_TIMEOUT
+      - USER_MANAGER_ENABLE
+      - USER_MANAGER_MAX_FAILED_LOGINS
+    hostname: user_manager
+    depends_on:
+      - redis
+    # command: [ "node", "--inspect=0.0.0.0:9229", "app.js" ]
+  #/user_manager
+
+
+#  #watchtower: monitor and update our running containers
+#  watchtower:
+#    image: v2tec/watchtower
+#    volumes:
+#      # - /var/run/docker.sock:/var/run/docker.sock
+#      - type: bind
+#        source: /var/run/docker.sock
+#        target: /var/run/docker.sock
+#    command: --interval 10 --debug
+#  #/watchtower


### PR DESCRIPTION
The big goal of this revision is to generate an installation that removes any (most) of the shared files between the host computer and our running containers.

Instead of trying to use a common `config/local.js` file to share configuration data among our containers, we are using an `.env` file to generate environment variables that are passed into our containers.

These changes touch just about every repository we own to implement.

In order to test this out:
-  check out this branch of the `ab-cli` on your local machine
-  then perform a sample install

here is a sample install that already includes all the questions filled out:
```
appbuilder install env --stack=env --port=8080 --dbExpose=true --dbPort=8889 --dbPassword=rO0t --tag=master --authType=login --runtime=jh/awsReady --relayEnabled=false --pwaURL=http://pwa.site.com --siteURL=http://auth.site.com --tenant.username=admin --tenant.password=admin --tenant.email=admin@email.com --tenant.url=https://adminTenant.site.url
```

Also test it with the `--develop` tag to verify a newly installed development environment works as well.

