### PR TITLE
fix stack name in dbinit-compose.yml

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -285,7 +285,7 @@ function copyDBInit(done) {
  * @param {cb(err)} done
  */
 function removeTempDBInitFiles(done) {
-   shell.rm("dbinit-compose.yml", "delme.yml");
+   shell.rm("dbinit-compose.yml");
    done();
 }
 

--- a/lib/utils/dockerStackWatch.js
+++ b/lib/utils/dockerStackWatch.js
@@ -92,7 +92,7 @@ module.exports = function (
 
                   if (response.code != 0) {
                      console.error(response.stderr);
-                     process.exit(0);
+                     process.exit(response.code);
                   }
 
                   // This was giving us problems on windows, docker v23.xxx

--- a/lib/utils/dockerStackWatch.js
+++ b/lib/utils/dockerStackWatch.js
@@ -27,7 +27,9 @@ const path = require("path");
 const async = require("async");
 const EventEmitter = require("events");
 const execCommand = require(path.join(__dirname, "execCommand.js"));
+const fs = require("fs");
 const os = require("os");
+const path = require("path");
 const shelljs = require("shelljs");
 
 var idCheck = null;
@@ -132,6 +134,11 @@ module.exports = function (
                      } else {
                         // some other error:
                         console.log(response.stderr);
+                        console.log("---- delme.yml ----");
+                        let pathDelMe = path.join(process.cwd(), "delme.yml");
+                        let contents = fs.readFileSync(pathDelMe, "utf8");
+                        console.log(contents);
+                        console.log("-------------------");
                         var deployError = new Error(response.stderr);
                         done(deployError);
                      }

--- a/lib/utils/dockerStackWatch.js
+++ b/lib/utils/dockerStackWatch.js
@@ -81,13 +81,19 @@ module.exports = function (
                // create a docker process for initializing the DB
                console.log(`... booting up ${composeFileName}`);
                var tryIt = () => {
+                  var response;
                   // use config to resolve any .env variables into a usable config
-                  shelljs.exec(
+                  response = shelljs.exec(
                      `docker-compose -f ${composeFileName} config > delme.yml`,
                      {
                         silent: true,
                      }
                   );
+
+                  if (response.code != 0) {
+                     console.error(response.stderr);
+                     process.exit(0);
+                  }
 
                   // This was giving us problems on windows, docker v23.xxx
                   // remove the "name: {stack}" from the delme.yml:
@@ -97,7 +103,6 @@ module.exports = function (
                         silent: true,
                      }
                   );
-                  var response;
                   if (process.arch == "arm64") {
                      // for Apple M1 chip, use docker-compose instead.
                      // 1 June 2023: getting an error when running our ab-db container:
@@ -134,8 +139,7 @@ module.exports = function (
                         // some other error:
                         console.log(response.stderr);
                         console.log("---- delme.yml ----");
-                        let pathDelMe = path.join(process.cwd(), "delme.yml");
-                        let contents = fs.readFileSync(pathDelMe, "utf8");
+                        let contents = fs.readFileSync("delme.yml", "utf8");
                         console.log(contents);
                         console.log("-------------------");
                         var deployError = new Error(response.stderr);

--- a/lib/utils/dockerStackWatch.js
+++ b/lib/utils/dockerStackWatch.js
@@ -27,8 +27,6 @@ const path = require("path");
 const async = require("async");
 const EventEmitter = require("events");
 const execCommand = require(path.join(__dirname, "execCommand.js"));
-const fs = require("fs");
-const os = require("os");
 const shelljs = require("shelljs");
 
 var idCheck = null;
@@ -82,40 +80,24 @@ module.exports = function (
                console.log(`... booting up ${composeFileName}`);
                var tryIt = () => {
                   var response;
-                  // use config to resolve any .env variables into a usable config
-                  response = shelljs.exec(
-                     `docker-compose -f ${composeFileName} config > delme.yml`,
-                     {
-                        silent: true,
-                     }
-                  );
 
-                  if (response.code != 0) {
-                     console.error(response.stderr);
-                     process.exit(response.code);
-                  }
+                  // Pass the env values need by dbinit-compose.yml to shelljs
+                  shelljs.env["MYSQL_PASSWORD"] = Options.dbPassword;
+                  shelljs.env["AB_DB_VERSION"] = Options.tag;
 
-                  // This was giving us problems on windows, docker v23.xxx
-                  // remove the "name: {stack}" from the delme.yml:
-                  shelljs.exec(
-                     `grep -v ^name:.${stack} delme.yml > temp && mv temp delme.yml`,
-                     {
-                        silent: true,
-                     }
-                  );
                   if (process.arch == "arm64") {
                      // for Apple M1 chip, use docker-compose instead.
                      // 1 June 2023: getting an error when running our ab-db container:
                      // no suitable node (unsupported platform on 1 node)
                      response = shelljs.exec(
-                        `docker-compose -f delme.yml up -d`,
+                        `docker-compose -f ${composeFileName} up -d`,
                         {
                            // silent: true,
                         }
                      );
                   } else {
                      response = shelljs.exec(
-                        `docker stack deploy -c delme.yml ${stack}`,
+                        `docker stack deploy -c ${composeFileName} ${stack}`,
                         {
                            silent: true,
                         }
@@ -138,10 +120,6 @@ module.exports = function (
                      } else {
                         // some other error:
                         console.log(response.stderr);
-                        console.log("---- delme.yml ----");
-                        let contents = fs.readFileSync("delme.yml", "utf8");
-                        console.log(contents);
-                        console.log("-------------------");
                         var deployError = new Error(response.stderr);
                         done(deployError);
                      }
@@ -189,9 +167,9 @@ module.exports = function (
             },
 
             (done) => {
+               clearTimeout(idCheck);
                if (!Options.keepRunning) {
                   // shut everything down
-                  clearTimeout(idCheck);
                   console.log("... shutting down");
                   shelljs.exec(`docker stack rm ${stack}`, { silent: true });
                }

--- a/lib/utils/dockerStackWatch.js
+++ b/lib/utils/dockerStackWatch.js
@@ -29,7 +29,6 @@ const EventEmitter = require("events");
 const execCommand = require(path.join(__dirname, "execCommand.js"));
 const fs = require("fs");
 const os = require("os");
-const path = require("path");
 const shelljs = require("shelljs");
 
 var idCheck = null;

--- a/templates/_dbinit-compose.yml
+++ b/templates/_dbinit-compose.yml
@@ -1,5 +1,4 @@
 version: "3.2"
-name: $STACKNAME
 volumes:
   mysql_data:
 

--- a/templates/_dbinit-compose.yml
+++ b/templates/_dbinit-compose.yml
@@ -1,4 +1,5 @@
 version: "3.2"
+name: $STACKNAME
 volumes:
   mysql_data:
 


### PR DESCRIPTION
Fixes an error when stack name was different then the folder name
```
Error: (root) Additional property name is not allowed

    at tryIt (C:\Users\Nate\AppData\Roaming\nvm\v18.16.1\node_modules\ab-cli\lib\utils\dockerStackWatch.js:135:43)
    at C:\Users\Nate\AppData\Roaming\nvm\v18.16.1\node_modules\ab-cli\lib\utils\dockerStackWatch.js:141:16
    at C:\Users\Nate\AppData\Roaming\nvm\v18.16.1\node_modules\ab-cli\node_modules\async\dist\async.js:3883:24
    at replenish (C:\Users\Nate\AppData\Roaming\nvm\v18.16.1\node_modules\ab-cli\node_modules\async\dist\async.js:1014:17)
    at C:\Users\Nate\AppData\Roaming\nvm\v18.16.1\node_modules\ab-cli\node_modules\async\dist\async.js:1019:9
    at eachOfLimit (C:\Users\Nate\AppData\Roaming\nvm\v18.16.1\node_modules\ab-cli\node_modules\async\dist\async.js:1044:24)
    at C:\Users\Nate\AppData\Roaming\nvm\v18.16.1\node_modules\ab-cli\node_modules\async\dist\async.js:1049:16
    at _parallel (C:\Users\Nate\AppData\Roaming\nvm\v18.16.1\node_modules\ab-cli\node_modules\async\dist\async.js:3882:5)
    at Object.series (C:\Users\Nate\AppData\Roaming\nvm\v18.16.1\node_modules\ab-cli\node_modules\async\dist\async.js:4738:5)
    at C:\Users\Nate\AppData\Roaming\nvm\v18.16.1\node_modules\ab-cli\lib\utils\dockerStackWatch.js:70:13
  ```