### PR TITLE
fix checking out ab_runtime branch from github worflow ref

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -219,9 +219,9 @@ function cloneRepo(done) {
 
    // Allow installing using a branch or commit in ab_runtime --runtime [branch/commit]
    if (Options.runtime) {
-      // Fetch PRs so we can check them out inside a github workflow
-      shell.exec("git fetch origin '+refs/pull/*:refs/remotes/pr/*'");
-      shell.exec(`git checkout ${Options.runtime}`);
+      shell.exec(
+         `git fetch origin ${Options.runtime} && git checkout FETCH_HEAD`
+      );
    }
 
    done();


### PR DESCRIPTION
 Fix an error we get when checking out a `ab_runtime` branch in CI
 ```
 error: pathspec 'refs/pull/366/merge' did not match any file(s) known to git
 ```
from [run](https://github.com/digi-serve/ab_runtime/actions/runs/8183082744/job/22542221509)