### PR TITLE
Remove BotManager from default developer install

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -29,3 +29,7 @@ max_line_length = 80
 [*.md]
 # do not remove any whitespace characters preceding newline characters
 trim_trailing_whitespace = false
+
+### custom for YAML files
+[*.{yml,yaml}]
+indent_size = 2

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -57,7 +57,7 @@ jobs:
         working-directory: ./ab-test
 
       - name: Wait for AB (Main Stack)
-        uses: ifaxity/wait-on-action@@v1.2.1
+        uses: ifaxity/wait-on-action@v1.2.1
         with:
           resource: http://localhost:80
           timeout: 300000

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -127,65 +127,65 @@ jobs:
 
       # - name: Take Down Test Stack
       # run: node ../index.js test down ab
-  podman-install-test:
-    name: Podman Install
-    runs-on: ubuntu-latest
-    env:
-      CYPRESS_RESPONSE_TIMEOUT: 200000
-      CYPRESS_DEFAULT_COMMAND_TIMEOUT: 30000
-      CYPRESS_RETRIES: 2
-    steps:
-      - run: sudo apt-get update & sudo apt-get -y install podman & systemctl --user enable --now podman.socket
-      # connect Docker CLI to Podman’s socket
-      - run: export DOCKER_HOST=unix://$XDG_RUNTIME_DIR/podman/podman.sock
+  # podman-install-test:
+  #   name: Podman Install
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     CYPRESS_RESPONSE_TIMEOUT: 200000
+  #     CYPRESS_DEFAULT_COMMAND_TIMEOUT: 30000
+  #     CYPRESS_RETRIES: 2
+  #   steps:
+  #     - run: sudo apt-get update & sudo apt-get -y install podman & systemctl --user enable --now podman.socket
+  #     # connect Docker CLI to Podman’s socket
+  #     - run: export DOCKER_HOST=unix://$XDG_RUNTIME_DIR/podman/podman.sock
 
-      - run: podman version
-      - run: podman compose --help
+  #     - run: podman version
+  #     - run: podman compose --help
 
-      - name: Checkout ab-cli
-        uses: actions/checkout@v2
+  #     - name: Checkout ab-cli
+  #       uses: actions/checkout@v2
 
-      - name: Install npm packages
-        run: npm i
+  #     - name: Install npm packages
+  #       run: npm i
 
-      - name: Install AppBuilder
-        run: node index.js install ab-test --stack=ab-test --port=8090 --tag=latest --dbExpose=true --dbPort=8888 --dbPassword=root --authType=login --relayEnabled=false --siteURL=http://localhost:8090 --tenant.username=admin --tenant.password=admin --tenant.email=admin@email.com --tenant.url=http://localhost:8090 --platform=podman
+  #     - name: Install AppBuilder
+  #       run: node index.js install ab-test --stack=ab-test --port=8090 --tag=latest --dbExpose=true --dbPort=8888 --dbPassword=root --authType=login --relayEnabled=false --siteURL=http://localhost:8090 --tenant.username=admin --tenant.password=admin --tenant.email=admin@email.com --tenant.url=http://localhost:8090 --platform=podman
 
-      # Give some time for the stack to come down fully
-      - run: sleep 15
-      - name: Launch Main Stack
-        run: ./UP.sh -t -q
-        working-directory: ./ab-test
+  #     # Give some time for the stack to come down fully
+  #     - run: sleep 15
+  #     - name: Launch Main Stack
+  #       run: ./UP.sh -t -q
+  #       working-directory: ./ab-test
 
-      - name: Wait for AB (Main Stack)
-        uses: ifaxity/wait-on-action@v1.2.1
-        with:
-          resource: http://localhost:8090
-          timeout: 300000
+  #     - name: Wait for AB (Main Stack)
+  #       uses: ifaxity/wait-on-action@v1.2.1
+  #       with:
+  #         resource: http://localhost:8090
+  #         timeout: 300000
 
-      - run: npm install pm2@latest -g
-      - name: Save Logs
-        run: pm2 start ./logs.js -- --toFile logs/ABServices.log
-        working-directory: ./ab-test
+  #     - run: npm install pm2@latest -g
+  #     - name: Save Logs
+  #       run: pm2 start ./logs.js -- --toFile logs/ABServices.log
+  #       working-directory: ./ab-test
 
-      - name: Run Cypress Tests (Main Stack)
-        run: npm run test:e2e:ab-runtime -- --browser chrome
-        working-directory: ./ab-test
+  #     - name: Run Cypress Tests (Main Stack)
+  #       run: npm run test:e2e:ab-runtime -- --browser chrome
+  #       working-directory: ./ab-test
 
-      - name: Save Screenshots
-        uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: cypress-screenshots
-          path: ./ab-test/test/e2e/cypress/screenshots
+  #     - name: Save Screenshots
+  #       uses: actions/upload-artifact@v4
+  #       if: failure()
+  #       with:
+  #         name: cypress-screenshots
+  #         path: ./ab-test/test/e2e/cypress/screenshots
 
-      - name: Save Service Logs
-        uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: ABServices.log
-          path: ./ab-test/logs/ABServices.log
+  #     - name: Save Service Logs
+  #       uses: actions/upload-artifact@v4
+  #       if: failure()
+  #       with:
+  #         name: ABServices.log
+  #         path: ./ab-test/logs/ABServices.log
 
-      - name: Take Down Main Stack
-        run: ./Down.sh
-        working-directory: ./ab-test
+  #     - name: Take Down Main Stack
+  #       run: ./Down.sh
+  #       working-directory: ./ab-test

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -60,7 +60,7 @@ jobs:
         uses: ifaxity/wait-on-action@v1.2.1
         with:
           resource: http://localhost:80
-          timeout: 300000
+          timeout: 600000
 
       - run: npm install pm2@latest -g
       - name: Save Logs

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -18,9 +18,9 @@ jobs:
         os: [ubuntu-latest] #, windows-latest] #,macos-latest]
         node: [18, 20, 21]
     env:
-         CYPRESS_RESPONSE_TIMEOUT: 200000
-         CYPRESS_DEFAULT_COMMAND_TIMEOUT: 30000
-         CYPRESS_RETRIES: 2
+      CYPRESS_RESPONSE_TIMEOUT: 200000
+      CYPRESS_DEFAULT_COMMAND_TIMEOUT: 30000
+      CYPRESS_RETRIES: 2
     steps:
       # - name: Install Docker (Macos)
       #   if: ${{ matrix.os == 'macos-latest'}}
@@ -38,7 +38,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
-          cache: 'npm'
+          cache: "npm"
 
       - name: Install npm packages
         run: npm i
@@ -57,7 +57,7 @@ jobs:
         working-directory: ./ab-test
 
       - name: Wait for AB (Main Stack)
-        uses: ifaxity/wait-on-action@v1.1.0
+        uses: ifaxity/wait-on-action@@v1.2.1
         with:
           resource: http://localhost:80
           timeout: 300000
@@ -66,6 +66,21 @@ jobs:
         run: npm run test:e2e:ab-runtime -- --browser chrome
         working-directory: ./ab-test
 
+      - name: Save Screenshots
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: cypress-screenshots
+          path: ./AppBuilder/test/e2e/cypress/screenshots
+
+      - name: Save Service Logs
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: ABServices.log
+          path: ./AppBuilder/logs/ABServices.log
+
+      # eslint-disable-next-line
       - name: Take Down Main Stack
         run: ./Down.sh
         working-directory: ./ab-test
@@ -106,19 +121,18 @@ jobs:
           path: ./ab-test/logs/ABServices.log
 
       # - name: Take Down Test Stack
-        # run: node ../index.js test down ab
+      # run: node ../index.js test down ab
   podman-install-test:
     name: Podman Install
     runs-on: ubuntu-latest
     env:
-         CYPRESS_RESPONSE_TIMEOUT: 200000
-         CYPRESS_DEFAULT_COMMAND_TIMEOUT: 30000
-         CYPRESS_RETRIES: 2
+      CYPRESS_RESPONSE_TIMEOUT: 200000
+      CYPRESS_DEFAULT_COMMAND_TIMEOUT: 30000
+      CYPRESS_RETRIES: 2
     steps:
       - run: sudo apt-get update & sudo apt-get -y install podman & systemctl --user enable --now podman.socket
       # connect Docker CLI to Podman’s socket
       - run: export DOCKER_HOST=unix://$XDG_RUNTIME_DIR/podman/podman.sock
-
 
       - run: podman version
       - run: podman compose --help
@@ -139,7 +153,7 @@ jobs:
         working-directory: ./ab-test
 
       - name: Wait for AB (Main Stack)
-        uses: ifaxity/wait-on-action@v1
+        uses: ifaxity/wait-on-action@v1.2.1
         with:
           resource: http://localhost:8090
           timeout: 300000
@@ -148,7 +162,20 @@ jobs:
         run: npm run test:e2e:ab-runtime -- --browser chrome
         working-directory: ./ab-test
 
+      - name: Save Screenshots
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: cypress-screenshots
+          path: ./AppBuilder/test/e2e/cypress/screenshots
+
+      - name: Save Service Logs
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: ABServices.log
+          path: ./AppBuilder/logs/ABServices.log
+
       - name: Take Down Main Stack
         run: ./Down.sh
         working-directory: ./ab-test
-

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -56,11 +56,11 @@ jobs:
         run: ./UP.sh -t -q
         working-directory: ./ab-test
 
-      - name: Wait for AB (Main Stack)
-        uses: ifaxity/wait-on-action@v1.2.1
-        with:
-          resource: http://localhost:80
-          timeout: 600000
+      # - name: Wait for AB (Main Stack)
+      #   uses: ifaxity/wait-on-action@v1.2.1
+      #   with:
+      #     resource: http://localhost:80
+      #     timeout: 600000
 
       - run: npm install pm2@latest -g
       - name: Save Logs

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -16,7 +16,7 @@ jobs:
         # windows runner does not suppport linux containers
         # see:
         os: [ubuntu-latest] #, windows-latest] #,macos-latest]
-        node: [20]
+        node: [18, 20, 21]
     env:
       CYPRESS_RESPONSE_TIMEOUT: 200000
       CYPRESS_DEFAULT_COMMAND_TIMEOUT: 30000

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -57,7 +57,7 @@ jobs:
         working-directory: ./ab-test
 
       - name: Wait for AB (Main Stack)
-        uses: ifaxity/wait-on-action@v1
+        uses: ifaxity/wait-on-action@v1.1.0
         with:
           resource: http://localhost:80
           timeout: 300000

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -16,7 +16,7 @@ jobs:
         # windows runner does not suppport linux containers
         # see:
         os: [ubuntu-latest] #, windows-latest] #,macos-latest]
-        node: [18, 20, 21]
+        node: [20]
     env:
       CYPRESS_RESPONSE_TIMEOUT: 200000
       CYPRESS_DEFAULT_COMMAND_TIMEOUT: 30000

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -62,6 +62,11 @@ jobs:
           resource: http://localhost:80
           timeout: 300000
 
+      - run: npm install pm2@latest -g
+      - name: Save Logs
+        run: pm2 start ./logs.js -- --toFile logs/ABServices.log
+        working-directory: ./ab-test
+
       - name: Run Cypress Tests (Main Stack)
         run: npm run test:e2e:ab-runtime -- --browser chrome
         working-directory: ./ab-test
@@ -71,14 +76,14 @@ jobs:
         if: failure()
         with:
           name: cypress-screenshots
-          path: ./AppBuilder/test/e2e/cypress/screenshots
+          path: ./ab-test/test/e2e/cypress/screenshots
 
       - name: Save Service Logs
         uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: ABServices.log
-          path: ./AppBuilder/logs/ABServices.log
+          path: ./ab-test/logs/ABServices.log
 
       # eslint-disable-next-line
       - name: Take Down Main Stack
@@ -158,6 +163,11 @@ jobs:
           resource: http://localhost:8090
           timeout: 300000
 
+      - run: npm install pm2@latest -g
+      - name: Save Logs
+        run: pm2 start ./logs.js -- --toFile logs/ABServices.log
+        working-directory: ./ab-test
+
       - name: Run Cypress Tests (Main Stack)
         run: npm run test:e2e:ab-runtime -- --browser chrome
         working-directory: ./ab-test
@@ -167,14 +177,14 @@ jobs:
         if: failure()
         with:
           name: cypress-screenshots
-          path: ./AppBuilder/test/e2e/cypress/screenshots
+          path: ./ab-test/test/e2e/cypress/screenshots
 
       - name: Save Service Logs
         uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: ABServices.log
-          path: ./AppBuilder/logs/ABServices.log
+          path: ./ab-test/logs/ABServices.log
 
       - name: Take Down Main Stack
         run: ./Down.sh

--- a/package-lock.json
+++ b/package-lock.json
@@ -1769,9 +1769,9 @@
          "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
       },
       "node_modules/axios": {
-         "version": "0.28.0",
-         "resolved": "https://registry.npmjs.org/axios/-/axios-0.28.0.tgz",
-         "integrity": "sha512-Tu7NYoGY4Yoc7I+Npf9HhUMtEEpV7ZiLH9yndTCoNhcpBH0kwcvFbzYN9/u5QKI5A6uefjsNNWaz5olJVYS62Q==",
+         "version": "0.28.1",
+         "resolved": "https://registry.npmjs.org/axios/-/axios-0.28.1.tgz",
+         "integrity": "sha512-iUcGA5a7p0mVb4Gm/sy+FSECNkPFT4y7wt6OM/CDpO/OnNCvSs3PoMG8ibrC9jRoGYU0gUK5pXVC4NPXq6lHRQ==",
          "dependencies": {
             "follow-redirects": "^1.15.0",
             "form-data": "^4.0.0",
@@ -1823,9 +1823,9 @@
          "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
       },
       "node_modules/brace-expansion": {
-         "version": "1.1.11",
-         "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-         "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+         "version": "1.1.12",
+         "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+         "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
          "dependencies": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1861,6 +1861,18 @@
          },
          "engines": {
             "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+         }
+      },
+      "node_modules/call-bind-apply-helpers": {
+         "version": "1.0.2",
+         "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+         "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+         "dependencies": {
+            "es-errors": "^1.3.0",
+            "function-bind": "^1.1.2"
+         },
+         "engines": {
+            "node": ">= 0.4"
          }
       },
       "node_modules/callsites": {
@@ -2016,9 +2028,9 @@
          }
       },
       "node_modules/cross-spawn": {
-         "version": "7.0.3",
-         "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-         "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+         "version": "7.0.6",
+         "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+         "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
          "dependencies": {
             "path-key": "^3.1.0",
             "shebang-command": "^2.0.0",
@@ -2071,10 +2083,23 @@
             "node": ">=6.0.0"
          }
       },
+      "node_modules/dunder-proto": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+         "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+         "dependencies": {
+            "call-bind-apply-helpers": "^1.0.1",
+            "es-errors": "^1.3.0",
+            "gopd": "^1.2.0"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         }
+      },
       "node_modules/ejs": {
-         "version": "3.1.7",
-         "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.7.tgz",
-         "integrity": "sha512-BIar7R6abbUxDA3bfXrO4DSgwo8I+fB5/1zgujl3HLLjwd6+9iOnrT+t3grn2qbk9vOgBubXOFwX2m9axoFaGw==",
+         "version": "3.1.10",
+         "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+         "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
          "dependencies": {
             "jake": "^10.8.5"
          },
@@ -2120,6 +2145,47 @@
          },
          "funding": {
             "url": "https://bevry.me/fund"
+         }
+      },
+      "node_modules/es-define-property": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+         "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+         "engines": {
+            "node": ">= 0.4"
+         }
+      },
+      "node_modules/es-errors": {
+         "version": "1.3.0",
+         "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+         "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+         "engines": {
+            "node": ">= 0.4"
+         }
+      },
+      "node_modules/es-object-atoms": {
+         "version": "1.1.1",
+         "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+         "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+         "dependencies": {
+            "es-errors": "^1.3.0"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         }
+      },
+      "node_modules/es-set-tostringtag": {
+         "version": "2.1.0",
+         "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+         "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+         "dependencies": {
+            "es-errors": "^1.3.0",
+            "get-intrinsic": "^1.2.6",
+            "has-tostringtag": "^1.0.2",
+            "hasown": "^2.0.2"
+         },
+         "engines": {
+            "node": ">= 0.4"
          }
       },
       "node_modules/escalade": {
@@ -2346,13 +2412,10 @@
          }
       },
       "node_modules/eslint/node_modules/semver": {
-         "version": "7.3.5",
-         "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-         "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+         "version": "7.7.3",
+         "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+         "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
          "dev": true,
-         "dependencies": {
-            "lru-cache": "^6.0.0"
-         },
          "bin": {
             "semver": "bin/semver.js"
          },
@@ -2537,9 +2600,9 @@
          }
       },
       "node_modules/filelist/node_modules/brace-expansion": {
-         "version": "2.0.1",
-         "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-         "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+         "version": "2.0.2",
+         "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+         "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
          "dependencies": {
             "balanced-match": "^1.0.0"
          }
@@ -2594,12 +2657,14 @@
          }
       },
       "node_modules/form-data": {
-         "version": "4.0.0",
-         "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-         "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+         "version": "4.0.5",
+         "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+         "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
          "dependencies": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.8",
+            "es-set-tostringtag": "^2.1.0",
+            "hasown": "^2.0.2",
             "mime-types": "^2.1.12"
          },
          "engines": {
@@ -2612,9 +2677,12 @@
          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
       },
       "node_modules/function-bind": {
-         "version": "1.1.1",
-         "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-         "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+         "version": "1.1.2",
+         "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+         "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
+         }
       },
       "node_modules/functional-red-black-tree": {
          "version": "1.0.1",
@@ -2630,6 +2698,41 @@
          "peer": true,
          "engines": {
             "node": ">=6.9.0"
+         }
+      },
+      "node_modules/get-intrinsic": {
+         "version": "1.3.0",
+         "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+         "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+         "dependencies": {
+            "call-bind-apply-helpers": "^1.0.2",
+            "es-define-property": "^1.0.1",
+            "es-errors": "^1.3.0",
+            "es-object-atoms": "^1.1.1",
+            "function-bind": "^1.1.2",
+            "get-proto": "^1.0.1",
+            "gopd": "^1.2.0",
+            "has-symbols": "^1.1.0",
+            "hasown": "^2.0.2",
+            "math-intrinsics": "^1.1.0"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
+         }
+      },
+      "node_modules/get-proto": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+         "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+         "dependencies": {
+            "dunder-proto": "^1.0.1",
+            "es-object-atoms": "^1.0.0"
+         },
+         "engines": {
+            "node": ">= 0.4"
          }
       },
       "node_modules/glob": {
@@ -2678,6 +2781,17 @@
             "url": "https://github.com/sponsors/sindresorhus"
          }
       },
+      "node_modules/gopd": {
+         "version": "1.2.0",
+         "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+         "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
+         }
+      },
       "node_modules/has": {
          "version": "1.0.3",
          "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -2695,6 +2809,42 @@
          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
          "engines": {
             "node": ">=4"
+         }
+      },
+      "node_modules/has-symbols": {
+         "version": "1.1.0",
+         "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+         "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
+         }
+      },
+      "node_modules/has-tostringtag": {
+         "version": "1.0.2",
+         "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+         "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+         "dependencies": {
+            "has-symbols": "^1.0.3"
+         },
+         "engines": {
+            "node": ">= 0.4"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/ljharb"
+         }
+      },
+      "node_modules/hasown": {
+         "version": "2.0.2",
+         "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+         "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+         "dependencies": {
+            "function-bind": "^1.1.2"
+         },
+         "engines": {
+            "node": ">= 0.4"
          }
       },
       "node_modules/iconv-lite": {
@@ -2944,9 +3094,9 @@
          "dev": true
       },
       "node_modules/js-yaml": {
-         "version": "3.14.1",
-         "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-         "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+         "version": "3.14.2",
+         "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+         "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
          "dev": true,
          "dependencies": {
             "argparse": "^1.0.7",
@@ -3043,16 +3193,12 @@
          "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
          "dev": true
       },
-      "node_modules/lru-cache": {
-         "version": "6.0.0",
-         "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-         "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-         "dev": true,
-         "dependencies": {
-            "yallist": "^4.0.0"
-         },
+      "node_modules/math-intrinsics": {
+         "version": "1.1.0",
+         "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+         "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
          "engines": {
-            "node": ">=10"
+            "node": ">= 0.4"
          }
       },
       "node_modules/mime-db": {
@@ -3110,9 +3256,15 @@
          "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
       },
       "node_modules/nanoid": {
-         "version": "3.1.31",
-         "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.31.tgz",
-         "integrity": "sha512-ZivnJm0o9bb13p2Ot5CpgC2rQdzB9Uxm/mFZweqm5eMViqOJe3PV6LU2E30SiLgheesmcPrjquqraoolONSA0A==",
+         "version": "3.3.11",
+         "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+         "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+         "funding": [
+            {
+               "type": "github",
+               "url": "https://github.com/sponsors/ai"
+            }
+         ],
          "bin": {
             "nanoid": "bin/nanoid.cjs"
          },
@@ -3860,9 +4012,9 @@
          }
       },
       "node_modules/word-wrap": {
-         "version": "1.2.3",
-         "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-         "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+         "version": "1.2.5",
+         "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+         "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
          "dev": true,
          "engines": {
             "node": ">=0.10.0"
@@ -3881,12 +4033,6 @@
          "dependencies": {
             "remove-trailing-spaces": "^1.0.0"
          }
-      },
-      "node_modules/yallist": {
-         "version": "4.0.0",
-         "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-         "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-         "dev": true
       }
    },
    "dependencies": {
@@ -5098,9 +5244,9 @@
          "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
       },
       "axios": {
-         "version": "0.28.0",
-         "resolved": "https://registry.npmjs.org/axios/-/axios-0.28.0.tgz",
-         "integrity": "sha512-Tu7NYoGY4Yoc7I+Npf9HhUMtEEpV7ZiLH9yndTCoNhcpBH0kwcvFbzYN9/u5QKI5A6uefjsNNWaz5olJVYS62Q==",
+         "version": "0.28.1",
+         "resolved": "https://registry.npmjs.org/axios/-/axios-0.28.1.tgz",
+         "integrity": "sha512-iUcGA5a7p0mVb4Gm/sy+FSECNkPFT4y7wt6OM/CDpO/OnNCvSs3PoMG8ibrC9jRoGYU0gUK5pXVC4NPXq6lHRQ==",
          "requires": {
             "follow-redirects": "^1.15.0",
             "form-data": "^4.0.0",
@@ -5143,9 +5289,9 @@
          "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
       },
       "brace-expansion": {
-         "version": "1.1.11",
-         "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-         "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+         "version": "1.1.12",
+         "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+         "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
          "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5161,6 +5307,15 @@
             "electron-to-chromium": "^1.5.73",
             "node-releases": "^2.0.19",
             "update-browserslist-db": "^1.1.1"
+         }
+      },
+      "call-bind-apply-helpers": {
+         "version": "1.0.2",
+         "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+         "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+         "requires": {
+            "es-errors": "^1.3.0",
+            "function-bind": "^1.1.2"
          }
       },
       "callsites": {
@@ -5276,9 +5431,9 @@
          }
       },
       "cross-spawn": {
-         "version": "7.0.3",
-         "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-         "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+         "version": "7.0.6",
+         "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+         "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
          "requires": {
             "path-key": "^3.1.0",
             "shebang-command": "^2.0.0",
@@ -5314,10 +5469,20 @@
             "esutils": "^2.0.2"
          }
       },
+      "dunder-proto": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+         "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+         "requires": {
+            "call-bind-apply-helpers": "^1.0.1",
+            "es-errors": "^1.3.0",
+            "gopd": "^1.2.0"
+         }
+      },
       "ejs": {
-         "version": "3.1.7",
-         "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.7.tgz",
-         "integrity": "sha512-BIar7R6abbUxDA3bfXrO4DSgwo8I+fB5/1zgujl3HLLjwd6+9iOnrT+t3grn2qbk9vOgBubXOFwX2m9axoFaGw==",
+         "version": "3.1.10",
+         "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+         "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
          "requires": {
             "jake": "^10.8.5"
          }
@@ -5346,6 +5511,35 @@
          "version": "6.18.0",
          "resolved": "https://registry.npmjs.org/envfile/-/envfile-6.18.0.tgz",
          "integrity": "sha512-IsYv64dtlNXTm4huvCBpbXsdZQurYUju9WoYCkSj+SDYpO3v4/dq346QsCnNZ3JcnWw0G3E6+saVkVtmPw98Gg=="
+      },
+      "es-define-property": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+         "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
+      },
+      "es-errors": {
+         "version": "1.3.0",
+         "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+         "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
+      },
+      "es-object-atoms": {
+         "version": "1.1.1",
+         "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+         "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+         "requires": {
+            "es-errors": "^1.3.0"
+         }
+      },
+      "es-set-tostringtag": {
+         "version": "2.1.0",
+         "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+         "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+         "requires": {
+            "es-errors": "^1.3.0",
+            "get-intrinsic": "^1.2.6",
+            "has-tostringtag": "^1.0.2",
+            "hasown": "^2.0.2"
+         }
       },
       "escalade": {
          "version": "3.2.0",
@@ -5453,13 +5647,10 @@
                "dev": true
             },
             "semver": {
-               "version": "7.3.5",
-               "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-               "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-               "dev": true,
-               "requires": {
-                  "lru-cache": "^6.0.0"
-               }
+               "version": "7.7.3",
+               "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+               "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+               "dev": true
             },
             "supports-color": {
                "version": "7.2.0",
@@ -5652,9 +5843,9 @@
          },
          "dependencies": {
             "brace-expansion": {
-               "version": "2.0.1",
-               "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-               "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+               "version": "2.0.2",
+               "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+               "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
                "requires": {
                   "balanced-match": "^1.0.0"
                }
@@ -5691,12 +5882,14 @@
          "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA=="
       },
       "form-data": {
-         "version": "4.0.0",
-         "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-         "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+         "version": "4.0.5",
+         "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+         "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
          "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.8",
+            "es-set-tostringtag": "^2.1.0",
+            "hasown": "^2.0.2",
             "mime-types": "^2.1.12"
          }
       },
@@ -5706,9 +5899,9 @@
          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
       },
       "function-bind": {
-         "version": "1.1.1",
-         "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-         "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+         "version": "1.1.2",
+         "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+         "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
       },
       "functional-red-black-tree": {
          "version": "1.0.1",
@@ -5722,6 +5915,32 @@
          "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
          "dev": true,
          "peer": true
+      },
+      "get-intrinsic": {
+         "version": "1.3.0",
+         "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+         "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+         "requires": {
+            "call-bind-apply-helpers": "^1.0.2",
+            "es-define-property": "^1.0.1",
+            "es-errors": "^1.3.0",
+            "es-object-atoms": "^1.1.1",
+            "function-bind": "^1.1.2",
+            "get-proto": "^1.0.1",
+            "gopd": "^1.2.0",
+            "has-symbols": "^1.1.0",
+            "hasown": "^2.0.2",
+            "math-intrinsics": "^1.1.0"
+         }
+      },
+      "get-proto": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+         "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+         "requires": {
+            "dunder-proto": "^1.0.1",
+            "es-object-atoms": "^1.0.0"
+         }
       },
       "glob": {
          "version": "7.2.0",
@@ -5754,6 +5973,11 @@
             "type-fest": "^0.20.2"
          }
       },
+      "gopd": {
+         "version": "1.2.0",
+         "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+         "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
+      },
       "has": {
          "version": "1.0.3",
          "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -5766,6 +5990,27 @@
          "version": "3.0.0",
          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+      },
+      "has-symbols": {
+         "version": "1.1.0",
+         "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+         "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
+      },
+      "has-tostringtag": {
+         "version": "1.0.2",
+         "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+         "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+         "requires": {
+            "has-symbols": "^1.0.3"
+         }
+      },
+      "hasown": {
+         "version": "2.0.2",
+         "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+         "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+         "requires": {
+            "function-bind": "^1.1.2"
+         }
       },
       "iconv-lite": {
          "version": "0.4.24",
@@ -5952,9 +6197,9 @@
          "dev": true
       },
       "js-yaml": {
-         "version": "3.14.1",
-         "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-         "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+         "version": "3.14.2",
+         "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+         "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
          "dev": true,
          "requires": {
             "argparse": "^1.0.7",
@@ -6030,14 +6275,10 @@
          "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
          "dev": true
       },
-      "lru-cache": {
-         "version": "6.0.0",
-         "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-         "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-         "dev": true,
-         "requires": {
-            "yallist": "^4.0.0"
-         }
+      "math-intrinsics": {
+         "version": "1.1.0",
+         "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+         "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
       },
       "mime-db": {
          "version": "1.52.0",
@@ -6082,9 +6323,9 @@
          "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
       },
       "nanoid": {
-         "version": "3.1.31",
-         "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.31.tgz",
-         "integrity": "sha512-ZivnJm0o9bb13p2Ot5CpgC2rQdzB9Uxm/mFZweqm5eMViqOJe3PV6LU2E30SiLgheesmcPrjquqraoolONSA0A=="
+         "version": "3.3.11",
+         "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+         "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="
       },
       "natural-compare": {
          "version": "1.4.0",
@@ -6630,9 +6871,9 @@
          }
       },
       "word-wrap": {
-         "version": "1.2.3",
-         "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-         "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+         "version": "1.2.5",
+         "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+         "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
          "dev": true
       },
       "wrappy": {
@@ -6648,12 +6889,6 @@
          "requires": {
             "remove-trailing-spaces": "^1.0.0"
          }
-      },
-      "yallist": {
-         "version": "4.0.0",
-         "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-         "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-         "dev": true
       }
    }
 }

--- a/templates/setup/.env
+++ b/templates/setup/.env
@@ -81,7 +81,7 @@ AB_USER_MANAGER_VERSION=<%= locals.tag_user_manager ? tag_user_manager : tag %>
 CYPRESS_BASE_URL=<%= cypressBaseURL %>
 CYPRESS_STACK=<%= cypressStack %>
 CYPRESS_DB_USER=root
-CYPRESS_DB_PASSWORD=root
+CYPRESS_DB_PASSWORD=<%= dbPassword %>
 
 ##
 ## Api_Sails

--- a/templates/setup/docker-compose.dev.yml
+++ b/templates/setup/docker-compose.dev.yml
@@ -39,7 +39,7 @@ services:
     # when there is a problem with : Error: ER_CRASHED_ON_USAGE: Table 'AAAAAA' is marked as crashed and should be repaired
     # this can happen with the alter table algorithm: try the safest(and slowest) COPY
     # eslint-disable-next-line
-    command:["mysqld", "--alter-algorithm=copy", "--wait-timeout=60", "--interactive-timeout=60"]
+    command: ["mysqld", "--alter-algorithm=copy", "--wait-timeout=60", "--interactive-timeout=60"]
   #/db
 
   #redis: use redis to allow cote services to find each other across a swarm

--- a/templates/setup/docker-compose.dev.yml
+++ b/templates/setup/docker-compose.dev.yml
@@ -38,13 +38,8 @@ services:
     ######
     # when there is a problem with : Error: ER_CRASHED_ON_USAGE: Table 'AAAAAA' is marked as crashed and should be repaired
     # this can happen with the alter table algorithm: try the safest(and slowest) COPY
-    command:
-      [
-        "mysqld",
-        "--alter-algorithm=copy",
-        "--wait-timeout=60",
-        "--interactive-timeout=60",
-      ]
+    # eslint-disable-next-line
+    command:["mysqld", "--alter-algorithm=copy", "--wait-timeout=60", "--interactive-timeout=60"]
   #/db
 
   #redis: use redis to allow cote services to find each other across a swarm

--- a/templates/setup/docker-compose.dev.yml
+++ b/templates/setup/docker-compose.dev.yml
@@ -22,6 +22,9 @@ services:
       - type: bind
         source: ./developer/web/assets
         target: /app/assets
+      - type: bind
+        source: ./developer/plugins
+        target: /app/assets/ab_plugins
     depends_on:
       - api_sails
     #/nginx

--- a/templates/setup/docker-compose.dev.yml
+++ b/templates/setup/docker-compose.dev.yml
@@ -24,7 +24,7 @@ services:
         target: /app/assets
     depends_on:
       - api_sails
-   #/nginx
+    #/nginx
 
   #db: use Maria DB as our backend DB
   db:
@@ -38,9 +38,14 @@ services:
     ######
     # when there is a problem with : Error: ER_CRASHED_ON_USAGE: Table 'AAAAAA' is marked as crashed and should be repaired
     # this can happen with the alter table algorithm: try the safest(and slowest) COPY
-    command: ["mysqld", "--alter-algorithm=copy" , "--wait-timeout=60", "--interactive-timeout=60"]
+    command:
+      [
+        "mysqld",
+        "--alter-algorithm=copy",
+        "--wait-timeout=60",
+        "--interactive-timeout=60",
+      ]
   #/db
-
 
   #redis: use redis to allow cote services to find each other across a swarm
   redis:
@@ -50,7 +55,6 @@ services:
       - redis_data:/data
     command: redis-server --appendonly yes
   #/redis
-
 
   #api_sails: our API end point
   api_sails:
@@ -91,9 +95,8 @@ services:
     depends_on:
       - redis
     working_dir: /app
-    command: [ "node", "--inspect=0.0.0.0:9229", "app_waitMysql.js" ]
+    command: ["node", "--inspect=0.0.0.0:9229", "app_waitMysql.js"]
   #/api_sails
-
 
   #appbuilder: (AppBuilder) A multi-tenant aware service to process our AppBuilder requests.
   appbuilder:
@@ -121,47 +124,45 @@ services:
       - redis
     working_dir: /app
     # command: npm run dev  # <-- runs nodemon and auto starts when code changes
-    command: [ "node", "--inspect=0.0.0.0:9229", "app.js" ]
+    command: ["node", "--inspect=0.0.0.0:9229", "app.js"]
   #/appbuilder
 
-
-  #bot_manager: our #slack bot service
-  bot_manager:
-    image: node
-    environment:
-      - COTE_DISCOVERY_REDIS_HOST=redis
-      # - BOT_DOCKERHUB_ENABLE
-      # - BOT_DOCKERHUB_PORT
-      # - BOT_SLACKBOT_ENABLE
-      # - BOT_SLACKBOT_TOKEN
-      # - BOT_SLACKBOT_NAME
-      # - BOT_SLACKBOT_CHANNEL
-      # - BOT_SLACKBOT_PORT
-      # - BOT_SLACKBOT_SIGNINGSECRET
-      # - BOT_SLACKBOT_SOCKETMODE
-      # - BOT_SLACKBOT_APPTOKEN
-      # - BOT_TRIGGERS
-      # - BOT_COMMANDS
-      # - BOT_HOST_SOCK_PATH
-      # - BOT_HOST_TCP_PORT
-      # - BOT_HOST_TCP_ACCESSTOKEN
-    volumes:
-      - type: bind
-        source: ./developer/bot_manager
-        target: /app
-      # sharing .sock files currently don't work on docker-for-mac:
-      # https://github.com/docker/for-mac/issues/483
-      # For a Mac host, configure config/local.js to hostConnection.tcp
-      # but it doesn't hurt to include the /tmp dir for all platforms.
-      - type: bind
-        source: /tmp
-        target: /tmp
-    depends_on:
-      - redis
-    working_dir: /app
-    command: [ "node", "--inspect=0.0.0.0:9229", "app.js" ]
-  #/bot_manager
-
+  # #bot_manager: our #slack bot service
+  # bot_manager:
+  #   image: node
+  #   environment:
+  #     - COTE_DISCOVERY_REDIS_HOST=redis
+  #     # - BOT_DOCKERHUB_ENABLE
+  #     # - BOT_DOCKERHUB_PORT
+  #     # - BOT_SLACKBOT_ENABLE
+  #     # - BOT_SLACKBOT_TOKEN
+  #     # - BOT_SLACKBOT_NAME
+  #     # - BOT_SLACKBOT_CHANNEL
+  #     # - BOT_SLACKBOT_PORT
+  #     # - BOT_SLACKBOT_SIGNINGSECRET
+  #     # - BOT_SLACKBOT_SOCKETMODE
+  #     # - BOT_SLACKBOT_APPTOKEN
+  #     # - BOT_TRIGGERS
+  #     # - BOT_COMMANDS
+  #     # - BOT_HOST_SOCK_PATH
+  #     # - BOT_HOST_TCP_PORT
+  #     # - BOT_HOST_TCP_ACCESSTOKEN
+  #   volumes:
+  #     - type: bind
+  #       source: ./developer/bot_manager
+  #       target: /app
+  #     # sharing .sock files currently don't work on docker-for-mac:
+  #     # https://github.com/docker/for-mac/issues/483
+  #     # For a Mac host, configure config/local.js to hostConnection.tcp
+  #     # but it doesn't hurt to include the /tmp dir for all platforms.
+  #     - type: bind
+  #       source: /tmp
+  #       target: /tmp
+  #   depends_on:
+  #     - redis
+  #   working_dir: /app
+  #   command: [ "node", "--inspect=0.0.0.0:9229", "app.js" ]
+  # #/bot_manager
 
   #custom_reports: A service for custom reports.
   custom_reports:
@@ -185,9 +186,8 @@ services:
     depends_on:
       - redis
     working_dir: /app
-    command: [ "node", "--inspect=0.0.0.0:9229", "app.js" ]
+    command: ["node", "--inspect=0.0.0.0:9229", "app.js"]
   #/custom_reports
-
 
   #definition_manager: (AppBuilder) A service to manage the definitions for a running AppBuilder platform.
   definition_manager:
@@ -211,9 +211,8 @@ services:
     depends_on:
       - redis
     working_dir: /app
-    command: [ "node", "--inspect=0.0.0.0:9229", "app.js" ]
+    command: ["node", "--inspect=0.0.0.0:9229", "app.js"]
   #/definition_manager
-
 
   #file_processor: A service to manage uploaded files.
   file_processor:
@@ -242,9 +241,8 @@ services:
     depends_on:
       - redis
     working_dir: /app
-    command: [ "node", "--inspect=0.0.0.0:9229", "app.js" ]
+    command: ["node", "--inspect=0.0.0.0:9229", "app.js"]
   #/file_processor
-
 
   #log_manager: (AppBuilder) A log manager for various AB operations
   log_manager:
@@ -272,9 +270,8 @@ services:
     depends_on:
       - redis
     working_dir: /app
-    command: [ "node", "--inspect=0.0.0.0:9229", "app.js" ]
+    command: ["node", "--inspect=0.0.0.0:9229", "app.js"]
   #/log_manager
-
 
   #notification_email: an smtp email service
   notification_email:
@@ -308,9 +305,8 @@ services:
     depends_on:
       - redis
     working_dir: /app
-    command: [ "node", "--inspect=0.0.0.0:9229", "app.js" ]
+    command: ["node", "--inspect=0.0.0.0:9229", "app.js"]
   #/notification_email
-
 
   #process_manager: (AppBuilder) a micro service to manage our process tasks
   process_manager:
@@ -333,9 +329,8 @@ services:
     depends_on:
       - redis
     working_dir: /app
-    command: [ "node", "--inspect=0.0.0.0:9229", "app.js" ]
+    command: ["node", "--inspect=0.0.0.0:9229", "app.js"]
   #/process_manager
-
 
   #relay: (Appbuilder} A service to handle the communications with our relay server.
   relay:
@@ -364,9 +359,8 @@ services:
     depends_on:
       - redis
     working_dir: /app
-    command: [ "node", "--inspect=0.0.0.0:9229", "app.js" ]
+    command: ["node", "--inspect=0.0.0.0:9229", "app.js"]
   #/relay
-
 
   #tenant_manager: (AppBuilder) A service to manage the site's tenants
   tenant_manager:
@@ -391,9 +385,8 @@ services:
     depends_on:
       - redis
     working_dir: /app
-    command: [ "node", "--inspect=0.0.0.0:9229", "app.js" ]
+    command: ["node", "--inspect=0.0.0.0:9229", "app.js"]
   #/tenant_manager
-
 
   #user_manager: (AppBuilder) A microservice for managing Users
   user_manager:
@@ -418,10 +411,8 @@ services:
     depends_on:
       - redis
     working_dir: /app
-    command: [ "node", "--inspect=0.0.0.0:9229", "app.js" ]
+    command: ["node", "--inspect=0.0.0.0:9229", "app.js"]
   #/user_manager
-
-
 #  #watchtower: monitor and update our running containers
 #  watchtower:
 #    image: v2tec/watchtower


### PR DESCRIPTION
We don't use BotManager anymore, so I'm removing it from our default --develop install configuration.

The project/code is still there, but it is not included in the docker compose files by default.

[fix] remove bot_manager from default developer install