### PR TITLE
Revert file_processor in .dev mode to use image:node

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -67,6 +67,9 @@ jobs:
         run: pm2 start ./logs.js -- --toFile logs/ABServices.log
         working-directory: ./ab-test
 
+      # Give time for stack to come up fully
+      - run: sleep 120s
+
       - name: Run Cypress Tests (Main Stack)
         run: npm run test:e2e:ab-runtime -- --browser chrome
         working-directory: ./ab-test

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -47,7 +47,7 @@ jobs:
         run: docker swarm init --advertise-addr 127.0.0.1
 
       - name: Install AppBuilder
-        run: node index.js install ab-test --stack=ab-test --develop --port=80 --tag=latest --dbExpose=true --dbPort=8888 --dbPassword=root --authType=login --relayEnabled=false --siteURL=http://localhost:80 --tenant.username=admin --tenant.password=admin --tenant.email=admin@email.com --tenant.url=http://localhost:80 --runtime=jh/CypressStack
+        run: node index.js install ab-test --stack=ab-test --develop --port=80 --tag=latest --dbExpose=true --dbPort=8888 --dbPassword=root --authType=login --relayEnabled=false --siteURL=http://localhost:80 --tenant.username=admin --tenant.password=admin --tenant.email=admin@email.com --tenant.url=http://localhost:80
 
       # Give some time for the stack to come down fully
       - run: sleep 15

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -47,11 +47,13 @@ jobs:
         run: docker swarm init --advertise-addr 127.0.0.1
 
       - name: Install AppBuilder
-        run: node index.js install ab-test --stack=ab-test --develop --port=80 --tag=latest --dbExpose=true --dbPort=8888 --dbPassword=root --authType=login --relayEnabled=false --siteURL=http://localhost:80 --tenant.username=admin --tenant.password=admin --tenant.email=admin@email.com --tenant.url=http://localhost:80
+        run: node index.js install ab-test --stack=ab-test --develop --port=80 --tag=latest --dbExpose=true --dbPort=8888 --dbPassword=root --authType=login --relayEnabled=false --siteURL=http://localhost:80 --tenant.username=admin --tenant.password=admin --tenant.email=admin@email.com --tenant.url=http://localhost:80 --runtime=jh/CypressStack
 
       # Give some time for the stack to come down fully
       - run: sleep 15
 
+      # Update Permissions: api_sails crashes if a local DB attempt is used
+      # and we don't have permission to write there.
       - name: update permissions
         run: chmod 777 ./ab-test/developer/api_sails
 

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -52,6 +52,9 @@ jobs:
       # Give some time for the stack to come down fully
       - run: sleep 15
 
+      - name: update permissions
+        run: chmod 777 ./ab-test/developer/api_sails
+
       - name: Launch Main Stack
         run: ./UP.sh -t -q
         working-directory: ./ab-test

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -67,6 +67,11 @@ jobs:
       #     resource: http://localhost:80
       #     timeout: 600000
 
+      # Migrate The TEST stack DB
+      - name: Migrate Test Stack DB
+        run: ./migrate.sh -t
+        working-directory: ./ab-test
+
       - run: npm install pm2@latest -g
       - name: Save Logs
         run: pm2 start ./logs.js -- --toFile logs/ABServices.log

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -67,11 +67,6 @@ jobs:
       #     resource: http://localhost:80
       #     timeout: 600000
 
-      # Migrate The TEST stack DB
-      - name: Migrate Test Stack DB
-        run: ./migrate.sh -t
-        working-directory: ./ab-test
-
       - run: npm install pm2@latest -g
       - name: Save Logs
         run: pm2 start ./logs.js -- --toFile logs/ABServices.log

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -70,6 +70,8 @@ jobs:
       # Give time for stack to come up fully
       - run: sleep 120s
 
+      - run: docker service ls
+
       - name: Run Cypress Tests (Main Stack)
         run: npm run test:e2e:ab-runtime -- --browser chrome
         working-directory: ./ab-test

--- a/lib/install.js
+++ b/lib/install.js
@@ -106,11 +106,13 @@ Command.run = function (options) {
             copyDBInit,
             initializeDB,
             runDbMigrations,
-            removeTempDBInitFiles,
             configTenantAdmin,
             installDeveloperFiles,
             compileUI,
             downStack,
+            initializeDBTest,
+            runDbMigrationsTest,
+            removeTempDBInitFiles,
             devInstallEndMessage,
          ],
          (err) => {
@@ -402,6 +404,25 @@ function initializeDB(done) {
    // done();
 }
 
+function initializeDBTest(done) {
+   console.log("... initialize the Test DB tables");
+   const options = { ...Options };
+   // Keep this stack running for DB migrations
+   options.keepRunning = true;
+   options.stack = `test_${Options.stack}`;
+   utils
+      .dbInit(options, "dbinit-compose.yml")
+      .then((skipped) => {
+         Options.__dbSkipped = skipped;
+         done();
+      })
+      .catch((err) => {
+         done(err);
+      });
+   // shell.exec(path.join(process.cwd(), "DBInit.js"));
+   // done();
+}
+
 /**
  * run our db migrations from migration manager
  */
@@ -412,6 +433,18 @@ async function runDbMigrations() {
    const params = {
       stack: Options.stack,
       keepRunning: true,
+      platform: Options.platform,
+   };
+   await utils.runDbMigrations(params);
+}
+
+async function runDbMigrationsTest() {
+   if (Options.__dbSkipped) return;
+
+   console.log("... run db migration scripts for test stack");
+   const params = {
+      stack: `test_${Options.stack}`,
+      keepRunning: false,
       platform: Options.platform,
    };
    await utils.runDbMigrations(params);

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -518,7 +518,7 @@ function questions(done) {
          Options.sailsSessionSecret = nanoid(32);
 
          Options.cypressBaseURL = `http://localhost:${Options.port ?? 80}`;
-         Options.cypressStack = Options.stack ?? "ab";
+         Options.cypressStack = `test_${Options.stack ?? "ab"}`;
 
          // console.log("Options:", Options);
          settingTags.then(done);

--- a/templates/setup/docker-compose.dev.yml
+++ b/templates/setup/docker-compose.dev.yml
@@ -214,7 +214,7 @@ services:
 
   #file_processor: A service to manage uploaded files.
   file_processor:
-    image: docker.io/digiserve/ab-file-processor:$AB_FILE_PROCESSOR_VERSION
+    image: node
     environment:
       - COTE_DISCOVERY_REDIS_HOST=redis
       - MYSQL_PASSWORD

--- a/templates/setup/docker-compose.dev.yml
+++ b/templates/setup/docker-compose.dev.yml
@@ -42,7 +42,13 @@ services:
     # when there is a problem with : Error: ER_CRASHED_ON_USAGE: Table 'AAAAAA' is marked as crashed and should be repaired
     # this can happen with the alter table algorithm: try the safest(and slowest) COPY
     # eslint-disable-next-line
-    command: ["mysqld", "--alter-algorithm=copy", "--wait-timeout=60", "--interactive-timeout=60"]
+    command:
+      [
+        "mysqld",
+        "--alter-algorithm=copy",
+        "--wait-timeout=60",
+        "--interactive-timeout=60",
+      ]
   #/db
 
   #redis: use redis to allow cote services to find each other across a swarm

--- a/templates/setup/docker-compose.dev.yml
+++ b/templates/setup/docker-compose.dev.yml
@@ -56,7 +56,9 @@ services:
 
   #api_sails: our API end point
   api_sails:
-    image: node
+    # NOTE: since our file_processor is using our docker image, we should use
+    # our api-sails image so USER permissions are correct between the two services.
+    image: docker.io/digiserve/ab-api-sails:$AB_API_SAILS_VERSION
     environment:
       - COTE_DISCOVERY_REDIS_HOST=redis
       - NODE_ENV=development
@@ -92,8 +94,9 @@ services:
       - files:/data
     depends_on:
       - redis
-    working_dir: /app
-    command: ["node", "--inspect=0.0.0.0:9229", "app_waitMysql.js"]
+    # NOTE: our working image already sets this up:
+    # working_dir: /app
+    # command: ["node", "--inspect=0.0.0.0:9229", "app_waitMysql.js"]
   #/api_sails
 
   #appbuilder: (AppBuilder) A multi-tenant aware service to process our AppBuilder requests.
@@ -214,7 +217,9 @@ services:
 
   #file_processor: A service to manage uploaded files.
   file_processor:
-    image: node
+    # NOTE: our docker image contains additional utils not found in the node
+    # image, so we use that instead.
+    image: docker.io/digiserve/ab-file-processor:$AB_FILE_PROCESSOR_VERSION
     environment:
       - COTE_DISCOVERY_REDIS_HOST=redis
       - MYSQL_PASSWORD


### PR DESCRIPTION
With the recent security updates to our Docker packages, our services no longer run as root.  

In a development environment, if our api_sails not using our docker image, it will run as the default user in the `node` container.

If we force file_processor to use our Docker image, it will default to a different "user" in unix.  Since api_sails and file_processor are sharing the same file system, then one package will not be able to access and read the uploaded files the other one is creating due to file permissions.

So in a dev environment, let's make sure they both use the default :  `image:node` so they user permissions are the same.


[fix] revert file_processor in .dev mode to use image:node